### PR TITLE
Always apply overflow on the ppw-table-container

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.scss
@@ -1,10 +1,11 @@
 @use '@angular/material' as mat;
 
 .ppw-table-container {
+    overflow: auto;
+
     &.fixed-height {
         max-height: var(--ppw-table-height, auto);
         padding-right: 16px;
-        overflow: auto;
     }
 }
 


### PR DESCRIPTION
This change's purpose is mainly for mobile devices/small screens.
A horizontal scrollbar will be shown when the ppw-table is wider than the screen.