### PR TITLE
Feature/more flexible expandable cards

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
@@ -7,9 +7,20 @@
         (closed)="panelOpenState = canBeCollapsed"
     >
         <mat-expansion-panel-header class="ppw-expandable-panel-header">
-            @if (cardTitle) {
-                <mat-panel-title>{{ cardTitle }}</mat-panel-title>
-            }
+            <mat-panel-title>
+                @if (cardTitle) {
+                    {{ cardTitle }}
+                } @else {
+                    <ng-content select="[ppw-expandable-card-title]"> </ng-content>
+                }
+            </mat-panel-title>
+            <mat-panel-description>
+                @if (cardDescription) {
+                    {{ cardDescription }}
+                } @else {
+                    <ng-content select="[ppw-expandable-card-description]"> </ng-content>
+                }
+            </mat-panel-description>
         </mat-expansion-panel-header>
         <ng-content></ng-content>
     </mat-expansion-panel>

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
@@ -28,6 +28,10 @@ mat-accordion.ppw-expandable-card-accordion {
             border-bottom-right-radius: 0;
         }
 
+        mat-expansion-panel-header.ppw-expandable-panel-header .mat-expansion-panel-header-description {
+            justify-content: end;
+        }
+
         .mat-expansion-panel-content {
             .mat-expansion-panel-body {
                 padding-top: 16px;

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
@@ -22,6 +22,7 @@ import {
 })
 export class ExpandableCardComponent {
     @Input() public cardTitle?: string
+    @Input() public cardDescription?: string
     @Input() public canBeCollapsed = true
     @Input() public openAsExpanded = true
     public panelOpenState = true

--- a/src/app/expandable-card/expandable-card-demo.component.html
+++ b/src/app/expandable-card/expandable-card-demo.component.html
@@ -1,9 +1,22 @@
-<ppw-expandable-card [cardTitle]="'Demo card which cannot be collapsed'" [canBeCollapsed]="false">
+<ppw-expandable-card
+    [cardTitle]="'Demo card which cannot be collapsed'"
+    [cardDescription]="'Description as property'"
+    [canBeCollapsed]="false"
+>
     <div>card contents</div>
 </ppw-expandable-card>
-<ppw-expandable-card [cardTitle]="'Demo card which can be collapsed'">
+<ppw-expandable-card>
+    <div ppw-expandable-card-title>
+        <span>Demo card which can be collapsed</span>
+    </div>
+    <div ppw-expandable-card-description class="flex-grow-1 flex-row justify-content-end">
+        <span>Description as content</span>
+    </div>
     <div>card contents</div>
 </ppw-expandable-card>
 <ppw-expandable-card [cardTitle]="'Demo card which can be opened'" [openAsExpanded]="false">
     <div>card contents</div>
+</ppw-expandable-card>
+<ppw-expandable-card>
+    <div>this is a card with a title or description in the header</div>
 </ppw-expandable-card>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -133,6 +133,10 @@ body {
     justify-content: space-between;
 }
 
+.justify-content-end {
+    justify-content: end;
+}
+
 .align-items-center {
     align-items: center;
 }


### PR DESCRIPTION
## Lib changes
- Added the option to add a title with ng content on expendable card
- Added the option to add a description to the expendable card header with a property
- Added the option to add a description to the expendable card header with ng content

## Demo changes
- Added description by property to first expendable card
- Changed the title for the second card by using a div with `ppw-expandable-card-title`
- Added descriptuib to the second card by using a div with `ppw-expandable-card-description`