### PR TITLE
Feature/expandable card header full width

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
@@ -7,14 +7,14 @@
         (closed)="panelOpenState = canBeCollapsed"
     >
         <mat-expansion-panel-header class="ppw-expandable-panel-header">
-            <mat-panel-title>
+            <mat-panel-title class="ppw-expandable-card-title">
                 @if (cardTitle) {
                     {{ cardTitle }}
                 } @else {
                     <ng-content select="[ppw-expandable-card-title]"> </ng-content>
                 }
             </mat-panel-title>
-            <mat-panel-description>
+            <mat-panel-description class="ppw-expandable-card-description">
                 @if (cardDescription) {
                     {{ cardDescription }}
                 } @else {

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
@@ -37,5 +37,14 @@ mat-accordion.ppw-expandable-card-accordion {
                 padding-top: 16px;
             }
         }
+
+        .ppw-expandable-card-title:empty,
+        .ppw-expandable-card-description:empty {
+            display: none;
+        }
+        .ppw-expandable-card-title:empty + .ppw-expandable-card-description:not(:empty),
+        .ppw-expandable-card-title:not(:empty):has(+ .ppw-expandable-card-description:empty) {
+            flex-grow: 1;
+        }
     }
 }

--- a/src/app/expandable-card/expandable-card-demo.component.html
+++ b/src/app/expandable-card/expandable-card-demo.component.html
@@ -20,3 +20,28 @@
 <ppw-expandable-card>
     <div>this is a card with a title or description in the header</div>
 </ppw-expandable-card>
+
+<ppw-expandable-card [openAsExpanded]="false">
+    <div ppw-expandable-card-title class="flex-grow-1">
+        <span>Demo card which can be opened with full-width title</span>
+    </div>
+    <div>card contents</div>
+</ppw-expandable-card>
+<ppw-expandable-card [openAsExpanded]="false">
+    <div ppw-expandable-card-description class="flex-grow-1">
+        <span>Demo card which can be opened with full-width description</span>
+    </div>
+    <div>card contents</div>
+</ppw-expandable-card>
+<ppw-expandable-card
+    [cardTitle]="'Demo card which can be opened with a full-width title passed as parameter'"
+    [openAsExpanded]="false"
+>
+    <div>card contents</div>
+</ppw-expandable-card>
+<ppw-expandable-card
+    [cardDescription]="'Demo card which can be opened with a full-width description passed as parameter'"
+    [openAsExpanded]="false"
+>
+    <div>card contents</div>
+</ppw-expandable-card>


### PR DESCRIPTION
Support a full-width title or description in the expandable card header.

Without this, it defaults to a `flex-grow: 1` for the title and a `flex-grow: 2` for the description, meaning one can never use the full width of the header to show longer text.