### PR TITLE
Feature/expandable card header height

### DIFF
--- a/projects/ppwcode/ng-common-components/README.md
+++ b/projects/ppwcode/ng-common-components/README.md
@@ -44,11 +44,13 @@ The following CSS variables are available for theming. Just add them to the `bod
 
 #### ppw-expandable-card
 
-| Variable name                                   | Extra info |
-| ----------------------------------------------- | ---------- |
-| `--ppw-expandable-card-header-background-color` |            |
-| `--ppw-expandable-card-header-indicator-color`  |            |
-| `--ppw-expandable-card-header-text-color`       |            |
+| Variable name                                   | Extra info       |
+| ----------------------------------------------- | ---------------- |
+| `--ppw-expandable-card-header-background-color` |                  |
+| `--ppw-expandable-card-header-indicator-color`  |                  |
+| `--ppw-expandable-card-header-text-color`       |                  |
+| `--ppw-expandable-card-header-height-collapsed` | Defaults to 32px |
+| `--ppw-expandable-card-header-height-expanded`  | Defaults to 32px |
 
 #### ppw-message-bar
 

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
@@ -28,6 +28,14 @@ mat-accordion.ppw-expandable-card-accordion {
             border-bottom-right-radius: 0;
         }
 
+        mat-expansion-panel-header.ppw-expandable-panel-header {
+            height: var(--ppw-expandable-card-header-height-collapsed);
+
+            &[aria-expanded='true'] {
+                height: var(--ppw-expandable-card-header-height-expanded);
+            }
+        }
+
         mat-expansion-panel-header.ppw-expandable-panel-header .mat-expansion-panel-header-description {
             justify-content: end;
         }

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.theme.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.theme.scss
@@ -2,4 +2,6 @@
     --ppw-expandable-card-header-background-color: var(--mat-expansion-header-background-color);
     --ppw-expandable-card-header-text-color: var(--mat-expansion-header-text-color);
     --ppw-expandable-card-header-indicator-color: var(--mat-expansion-header-indicator-color);
+    --ppw-expandable-card-header-height-collapsed: 32px;
+    --ppw-expandable-card-header-height-expanded: 32px;
 }

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
@@ -1,10 +1,6 @@
 import { Component, Input, ViewEncapsulation } from '@angular/core'
 
-import {
-    MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
-    MatExpansionModule,
-    MatExpansionPanelDefaultOptions
-} from '@angular/material/expansion'
+import { MatExpansionModule } from '@angular/material/expansion'
 
 @Component({
     selector: 'ppw-expandable-card',
@@ -12,12 +8,6 @@ import {
     styleUrls: ['./expandable-card.component.scss', './expandable-card.component.theme.scss'],
     imports: [MatExpansionModule],
     encapsulation: ViewEncapsulation.None,
-    providers: [
-        {
-            provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
-            useValue: { expandedHeight: '32px', collapsedHeight: '32px' } as MatExpansionPanelDefaultOptions
-        }
-    ],
     standalone: true
 })
 export class ExpandableCardComponent {

--- a/src/app/expandable-card/expandable-card-demo.component.html
+++ b/src/app/expandable-card/expandable-card-demo.component.html
@@ -45,3 +45,13 @@
 >
     <div>card contents</div>
 </ppw-expandable-card>
+
+<ppw-expandable-card class="specific-heights-card">
+    <div ppw-expandable-card-title>
+        <span>Demo card which can be collapsed and has a specific height</span>
+    </div>
+    <div ppw-expandable-card-description class="flex-grow-1 flex-row justify-content-end">
+        <span>Description as content</span>
+    </div>
+    <div>card contents</div>
+</ppw-expandable-card>

--- a/src/app/expandable-card/expandable-card-demo.component.scss
+++ b/src/app/expandable-card/expandable-card-demo.component.scss
@@ -1,0 +1,4 @@
+.specific-heights-card {
+    --ppw-expandable-card-header-height-collapsed: 48px;
+    --ppw-expandable-card-header-height-expanded: 64px;
+}


### PR DESCRIPTION
Support CSS variables to define the height of the expandable card header.

The CSS variables added in this feature are:
`--ppw-expandable-card-header-height-collapsed`
`--ppw-expandable-card-header-height-expanded`