### PR TITLE
fix(common-components): set panelOpenState on expandable card correctly

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.html
@@ -4,7 +4,7 @@
         [expanded]="openAsExpanded()"
         [disabled]="!canBeCollapsed()"
         (opened)="panelOpenState = true"
-        (closed)="panelOpenState = canBeCollapsed()"
+        (closed)="panelOpenState = false"
     >
         <mat-expansion-panel-header class="ppw-expandable-panel-header">
             <mat-panel-title class="ppw-expandable-card-title">

--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, InputSignal, ViewEncapsulation } from '@angular/core'
+import { Component, input, InputSignal, ViewEncapsulation, OnInit } from '@angular/core'
 
 import { MatExpansionModule } from '@angular/material/expansion'
 
@@ -10,12 +10,16 @@ import { MatExpansionModule } from '@angular/material/expansion'
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ExpandableCardComponent {
+export class ExpandableCardComponent implements OnInit {
     // Inputs
     cardTitle: InputSignal<string | undefined> = input()
     cardDescription: InputSignal<string | undefined> = input()
     canBeCollapsed: InputSignal<boolean> = input(true)
     openAsExpanded: InputSignal<boolean> = input(true)
 
-    public panelOpenState = true
+    public panelOpenState!: boolean
+
+    public ngOnInit(): void {
+        this.panelOpenState = this.openAsExpanded()
+    }
 }

--- a/src/app/expandable-card/expandable-card-demo.component.html
+++ b/src/app/expandable-card/expandable-card-demo.component.html
@@ -55,3 +55,10 @@
     </div>
     <div>card contents</div>
 </ppw-expandable-card>
+
+<ppw-expandable-card #conditionalCard cardTitle="Card with expansion state information" [openAsExpanded]="false">
+    <div ppw-expandable-card-description class="flex-grow-1 flex-row justify-content-end">
+        <span>Is expanded: {{ conditionalCard.panelOpenState }}</span>
+    </div>
+    <div>card contents</div>
+</ppw-expandable-card>

--- a/src/app/expandable-card/expandable-card-demo.component.ts
+++ b/src/app/expandable-card/expandable-card-demo.component.ts
@@ -6,6 +6,6 @@ import { ExpandableCardComponent } from '@ppwcode/ng-common-components'
     templateUrl: './expandable-card-demo.component.html',
     styleUrls: ['./expandable-card-demo.component.scss'],
     standalone: true,
-    imports: [ExpandableCardDemoComponent, ExpandableCardComponent]
+    imports: [ExpandableCardComponent]
 })
 export class ExpandableCardDemoComponent {}


### PR DESCRIPTION
Bugfix panelOpenState property on the expandable card component.
