### PR TITLE
Rename 'reset' to 'restart' since there are warnings explaining that …

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/search-filter/search-filter.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/search-filter/search-filter.component.ts
@@ -19,5 +19,9 @@ export class SearchFilterComponent {
 
     // Outputs
     public search: OutputEmitterRef<void> = output<void>()
-    public reset: OutputEmitterRef<void> = output<void>()
+    public clear: OutputEmitterRef<void> = output<void>()
+    /**
+     * @deprecated This output will be removed in v20. It should be replaced with the `restart` output.
+     */
+    public reset: OutputEmitterRef<void> = this.clear
 }

--- a/src/app/filter-table/filter-table.component.html
+++ b/src/app/filter-table/filter-table.component.html
@@ -1,5 +1,5 @@
 @if (searchForm) {
-    <ppw-search-filter (search)="performSearch()" (reset)="performReset()" [submitDisabled]="searchForm.invalid">
+    <ppw-search-filter (search)="performSearch()" (clear)="performReset()" [submitDisabled]="searchForm.invalid">
         <form [formGroup]="searchForm" class="flex-row gap-8">
             <mat-form-field>
                 <mat-label>firstName</mat-label>


### PR DESCRIPTION
Rename 'reset' to 'restart' since there are warnings explaining that the word 'reset' is a reserved word.

For now, I support both outputs, in v20 we should remove the reset.