### PR TITLE
Move the opinionated definition of the margins on the expandable-card…

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/expandable-card/expandable-card.component.scss
@@ -6,15 +6,6 @@ mat-accordion.ppw-expandable-card-accordion {
     --mat-expansion-header-focus-state-layer-color: var(--ppw-expandable-card-header-background-color);
 
     mat-expansion-panel.ppw-expandable-panel {
-        margin: 8px;
-
-        &.mat-expansion-panel-spacing:first-child {
-            margin-top: 8px !important;
-        }
-        &.mat-expansion-panel-spacing:last-child {
-            margin-bottom: 8px !important;
-        }
-
         mat-expansion-panel-header.ppw-expandable-panel-header,
         mat-expansion-panel-header.ppw-expandable-panel-header:hover,
         mat-expansion-panel-header.ppw-expandable-panel-header:focus,

--- a/projects/ppwcode/ng-common-components/src/lib/search-filter/search-filter.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/search-filter/search-filter.component.scss
@@ -1,3 +1,0 @@
-mat-card {
-    margin: 8px;
-}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -238,3 +238,20 @@ div.page-toggles {
         }
     }
 }
+
+ppw-search-filter {
+    mat-card {
+        margin: 8px;
+    }
+}
+
+mat-expansion-panel.ppw-expandable-panel {
+    margin: 8px;
+
+    &.mat-expansion-panel-spacing:first-child {
+        margin-top: 8px !important;
+    }
+    &.mat-expansion-panel-spacing:last-child {
+        margin-bottom: 8px !important;
+    }
+}


### PR DESCRIPTION
Move the opinionated definition of the margins on the expandable-card and the search-filter to the example app.

It's not our components that should decide what the margin should be, nor to have to override it when using it with the Material defaults.