### PR TITLE
Add options for pagination query params

### DIFF
--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination.spec.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { mixinPagination, CanPage } from './pagination';
+import { providePaginationOptions } from '../pagination-options';
+import { PageEvent } from '@angular/material/paginator';
+import { RelativeNavigationCtor } from '../relative-navigation';
+
+@Component({
+  template: '',
+})
+class TestComponent {}
+
+describe('PaginationMixin', () => {
+  let component: CanPage;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [TestComponent],
+      providers: [
+        providePaginationOptions(),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const TestClass = mixinPagination(TestComponent as RelativeNavigationCtor);
+    component = new TestClass();
+  });
+
+  it('should use default pagination options', async () => {
+    spyOn(component, 'relativeNavigation').and.returnValue(Promise.resolve(true));
+    await component.navigateToPage(2);
+    expect(component.relativeNavigation).toHaveBeenCalledWith([], {
+      queryParams: { page: 2 },
+      queryParamsHandling: 'merge',
+      skipLocationChange: false,
+      replaceUrl: true,
+    });
+  });
+
+  it('should use custom pagination options', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [TestComponent],
+      providers: [
+        providePaginationOptions({ skipLocationChange: true, replaceUrl: false }),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const TestClass = mixinPagination(TestComponent as RelativeNavigationCtor);
+    component = new TestClass();
+
+    spyOn(component, 'relativeNavigation').and.returnValue(Promise.resolve(true));
+    await component.navigateToPage(2);
+    expect(component.relativeNavigation).toHaveBeenCalledWith([], {
+      queryParams: { page: 2 },
+      queryParamsHandling: 'merge',
+      skipLocationChange: true,
+      replaceUrl: false,
+    });
+  });
+});

--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
@@ -3,6 +3,8 @@ import { distinctUntilChanged, map, Observable } from 'rxjs'
 import { watchNumberQueryParam } from '../routing'
 import { Constructor } from '@ppwcode/ng-common'
 import { RelativeNavigationCtor } from '../relative-navigation'
+import { PaginationOptions, PAGINATION_OPTIONS } from '../pagination-options'
+import { inject } from '@angular/core'
 
 /**
  * Interface describing something that supports pagination.
@@ -35,6 +37,8 @@ export type CanPageCtor = Constructor<CanPage>
  */
 export const mixinPagination = <T extends RelativeNavigationCtor>(base: T): T & CanPageCtor => {
     return class extends base implements CanPage {
+        private readonly paginationOptions: PaginationOptions = inject(PAGINATION_OPTIONS)
+
         public page$ = this.watchPageIndexParam('page')
         public pageSize$ = this.watchPageSizeParam('pageSize')
         public defaultPageSize = 20
@@ -62,7 +66,9 @@ export const mixinPagination = <T extends RelativeNavigationCtor>(base: T): T & 
                 queryParams: {
                     [queryParamName]: page
                 },
-                queryParamsHandling: 'merge'
+                queryParamsHandling: 'merge',
+                skipLocationChange: this.paginationOptions.skipLocationChange,
+                replaceUrl: this.paginationOptions.replaceUrl
             })
         }
     }

--- a/projects/ppwcode/ng-router/src/lib/pagination-options.ts
+++ b/projects/ppwcode/ng-router/src/lib/pagination-options.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+export interface PaginationOptions {
+  skipLocationChange: boolean;
+  replaceUrl: boolean;
+}
+
+export const PAGINATION_OPTIONS = new InjectionToken<PaginationOptions>('PAGINATION_OPTIONS');
+
+export function providePaginationOptions(options: Partial<PaginationOptions> = {}): { provide: InjectionToken<PaginationOptions>; useValue: PaginationOptions } {
+  const defaultOptions: PaginationOptions = {
+    skipLocationChange: false,
+    replaceUrl: true,
+  };
+
+  return {
+    provide: PAGINATION_OPTIONS,
+    useValue: { ...defaultOptions, ...options },
+  };
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader'
 import { PPW_ASYNC_RESULT_DEFAULT_OPTIONS, PpwAsyncResultDefaultOptions } from '@ppwcode/ng-async'
 import { provideGlobalErrorHandler } from '@ppwcode/ng-common'
 import { PPW_TABLE_DEFAULT_OPTIONS } from '@ppwcode/ng-common-components'
-import { TranslatedPageTitleStrategy } from '@ppwcode/ng-router'
+import { TranslatedPageTitleStrategy, providePaginationOptions } from '@ppwcode/ng-router'
 import { WireframeComponent } from '@ppwcode/ng-wireframe'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
@@ -84,6 +84,10 @@ const ppwcodeComponents = [WireframeComponent]
         provideTranslateService({
             defaultLanguage: 'en',
             loader: { provide: TranslateLoader, useFactory: createTranslateLoader, deps: [HttpClient] }
+        }),
+        providePaginationOptions({
+            skipLocationChange: false,
+            replaceUrl: true
         })
     ]
 })


### PR DESCRIPTION
Add options for pagination query params to the Angular SDK.

* Add a new file `projects/ppwcode/ng-router/src/lib/pagination-options.ts` to define the `providePaginationOptions` method and an injectable token for pagination options.
* Update `projects/ppwcode/ng-router/src/lib/mixins/pagination.ts` to import and inject the `PAGINATION_OPTIONS` token, and update the `navigateToPage` method to include `skipLocationChange` and `replaceUrl` options.
* Add tests for the new pagination options in `projects/ppwcode/ng-router/src/lib/mixins/pagination.spec.ts`, including tests for default and custom values.
* Update the example app in `src/app/app.module.ts` to use the new `providePaginationOptions` method with custom values for `skipLocationChange` and `replaceUrl`.

