### PR TITLE
Bugfix mixinDetectFormChanged - Do not take empty properties of nested objects into account

### DIFF
--- a/projects/ppwcode/ng-forms/src/lib/form-changes-detection.ts
+++ b/projects/ppwcode/ng-forms/src/lib/form-changes-detection.ts
@@ -63,13 +63,25 @@ export const mixinDetectFormChanges = <T extends Constructor<object>>(base?: T):
         }
 
         /**
-         * Removes properties with null or undefined value from the given object
+         * Removes properties with null or undefined value from the given object,
+         * including nested objects
          */
         private getValuable<T extends object, V = Valuable<T>>(obj: T): V {
             return Object.fromEntries(
-                Object.entries(obj).filter(
-                    ([, v]) => !((typeof v === 'string' && !v.length) || v === null || typeof v === 'undefined')
-                )
+                Object.entries(obj)
+                    .map(([key, value]) => {
+                        if (value && typeof value === 'object' && !Array.isArray(value)) {
+                            // Recursively clean nested objects
+                            const valuable: V | undefined = Object.keys(value).length
+                                ? this.getValuable(value)
+                                : undefined
+                            return [key, valuable]
+                        }
+                        return [key, value]
+                    })
+                    .filter(
+                        ([, v]) => !((typeof v === 'string' && !v.length) || v === null || typeof v === 'undefined')
+                    )
             ) as V
         }
     }


### PR DESCRIPTION
When comparing the raw value of the form to detect changes, the null and empty values are not taken into account. This behavior was only applied to the base object's properties but did not extend to nested objects.

To ensure uniform handling, the function has been updated to work recursively, correctly filtering out null, undefined, and empty values from both top-level and nested properties.

See example of a faulty detected change below for reference:
Initial value:
```
{
    "status": "ACTIVE",
    "designatedBeneficiaries": false,
    "bankAccount": {
        "iban": "",
        "bic": "",
        "useBankAccount": false
    }
}
```

Updated value:
```
{
    "status": "ACTIVE",
    "designatedBeneficiaries": false,
    "bankAccount": {
        "iban": "",
        "bic": null,               //  <= changed from "" to null
        "useBankAccount": false
    }
}
```

### Would be nice to have this fix in a v18 release.