### PR TITLE
feat(forms): extend form control generators to accept async validators

### DIFF
--- a/projects/ppwcode/ng-forms/src/lib/generators.spec.ts
+++ b/projects/ppwcode/ng-forms/src/lib/generators.spec.ts
@@ -1,0 +1,72 @@
+import { FormControl, Validators, ValidationErrors } from '@angular/forms'
+import { Observable, of } from 'rxjs'
+import { createNonNullableControl, createNullableControl } from './generators'
+
+// Mock async validator
+const mockAsyncValidator = (): Observable<ValidationErrors | null> => {
+    return of(null)
+}
+
+describe('Form Control Generators', () => {
+    describe('createNonNullableControl', () => {
+        it('should create a control with array of validators (old style)', () => {
+            const control = createNonNullableControl('test', [Validators.required])
+
+            expect(control).toBeInstanceOf(FormControl)
+            expect(control.value).toBe('test')
+            expect(control.hasValidator(Validators.required)).toBe(true)
+        })
+
+        it('should create a control with validator options (new style)', () => {
+            const control = createNonNullableControl('test', {
+                validators: [Validators.required],
+                asyncValidators: [mockAsyncValidator]
+            })
+
+            expect(control).toBeInstanceOf(FormControl)
+            expect(control.value).toBe('test')
+            expect(control.hasValidator(Validators.required)).toBe(true)
+            expect(control.hasAsyncValidator(mockAsyncValidator)).toBe(true)
+        })
+
+        it('should create a disabled control', () => {
+            const control = createNonNullableControl('test', [], true)
+
+            expect(control.disabled).toBe(true)
+        })
+    })
+
+    describe('createNullableControl', () => {
+        it('should create a control with array of validators (old style)', () => {
+            const control = createNullableControl('test', [Validators.required])
+
+            expect(control).toBeInstanceOf(FormControl)
+            expect(control.value).toBe('test')
+            expect(control.hasValidator(Validators.required)).toBe(true)
+        })
+
+        it('should create a control with validator options (new style)', () => {
+            const control = createNullableControl('test', {
+                validators: [Validators.required],
+                asyncValidators: [mockAsyncValidator]
+            })
+
+            expect(control).toBeInstanceOf(FormControl)
+            expect(control.value).toBe('test')
+            expect(control.hasValidator(Validators.required)).toBe(true)
+            expect(control.hasAsyncValidator(mockAsyncValidator)).toBe(true)
+        })
+
+        it('should create a disabled control', () => {
+            const control = createNullableControl('test', [], true)
+
+            expect(control.disabled).toBe(true)
+        })
+
+        it('should create a control with null value', () => {
+            const control = createNullableControl(null)
+
+            expect(control.value).toBeNull()
+        })
+    })
+})

--- a/projects/ppwcode/ng-forms/src/lib/generators.ts
+++ b/projects/ppwcode/ng-forms/src/lib/generators.ts
@@ -1,26 +1,85 @@
-import { FormControl, ValidatorFn } from '@angular/forms'
+import { AsyncValidatorFn, FormControl, ValidatorFn } from '@angular/forms'
 
-export const createNonNullableControl = <T>(value: T, validators: Array<ValidatorFn> = [], disabled = false) => {
+export type ControlGeneratorValidatorOptions = {
+    validators?: Array<ValidatorFn>
+    asyncValidators?: Array<AsyncValidatorFn>
+}
+
+/**
+ * Creates a non-nullable FormControl with the given value and validators.
+ * A non-nullable control cannot have a null value.
+ *
+ * @param value - The initial value of the control
+ * @param validatorsOrOptions - An array of validators OR an object containing validators and asyncValidators
+ * @param disabled - Whether the control should be disabled
+ * @returns A new FormControl instance
+ *
+ * @example
+ * const control1 = createNonNullableControl('test', [Validators.required]);
+ *
+ * @example
+ * const control2 = createNonNullableControl('test', {
+ *   validators: [Validators.required],
+ *   asyncValidators: [asyncValidator()]
+ * });
+ */
+export const createNonNullableControl = <T>(
+    value: T,
+    validatorsOrOptions: Array<ValidatorFn> | ControlGeneratorValidatorOptions = [],
+    disabled = false
+) => {
+    const options = Array.isArray(validatorsOrOptions) ? { validators: validatorsOrOptions } : validatorsOrOptions
+
     return new FormControl<T>(
         {
             value,
             disabled
         },
         {
-            validators,
+            validators: options.validators,
+            asyncValidators: options.asyncValidators,
             nonNullable: true
         }
     )
 }
 
-export const createNullableControl = <T>(value: T, validators: Array<ValidatorFn> = [], disabled = false) => {
+/**
+ * Creates a nullable FormControl with the given value and validators.
+ * A nullable control can have a null value.
+ *
+ * @param value - The initial value of the control
+ * @param validatorsOrOptions - An array of validators OR an object containing validators and asyncValidators
+ * @param disabled - Whether the control should be disabled
+ * @returns A new FormControl instance
+ *
+ * @example
+ * const control1 = createNullableControl('test', [Validators.required]);
+ *
+ * @example
+ * const control2 = createNullableControl('test', {
+ *   validators: [Validators.required],
+ *   asyncValidators: [asyncValidator()]
+ * });
+ *
+ * @example
+ * // With null value
+ * const control3 = createNullableControl(null);
+ */
+export const createNullableControl = <T>(
+    value: T,
+    validatorsOrOptions: Array<ValidatorFn> | ControlGeneratorValidatorOptions = [],
+    disabled = false
+) => {
+    const options = Array.isArray(validatorsOrOptions) ? { validators: validatorsOrOptions } : validatorsOrOptions
+
     return new FormControl<T>(
         {
             value,
             disabled
         },
         {
-            validators
+            validators: options.validators,
+            asyncValidators: options.asyncValidators
         }
     )
 }


### PR DESCRIPTION
This pull request enhances the `createNonNullableControl` and `createNullableControl` functions in the `projects/ppwcode/ng-forms` library to support both synchronous and asynchronous validators. It also introduces comprehensive unit tests for these functions. The most important changes are summarized below:

### Enhancements to Form Control Generators

* **Added support for asynchronous validators**: Updated `createNonNullableControl` and `createNullableControl` to accept an object with `validators` and `asyncValidators` as an alternative to an array of validators. 
* **Introduced `ValidatorOptions` type**: Defined a new type to encapsulate `validators` and `asyncValidators` for improved code clarity. 

### Documentation Improvements

* **Added JSDoc comments**: Documented the `createNonNullableControl` and `createNullableControl` functions with detailed descriptions and examples. 

### Unit Tests

* **Comprehensive test coverage**: Added unit tests for both `createNonNullableControl` and `createNullableControl` to cover various scenarios, including synchronous and asynchronous validators, disabled controls, and nullable values. 