### PR TITLE
Redefine type for the route interpolationParams from Array<unknown> to the built-in router Params

### DIFF
--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.pipe.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.pipe.ts
@@ -1,6 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core'
 import { RouteMapRoute } from '../route-map-route'
 import { interpolateRoutePath } from '../route-retrieval'
+import { Params } from '@angular/router'
 
 /**
  * Gets the fully interpolated path for the given route.
@@ -16,7 +17,7 @@ import { interpolateRoutePath } from '../route-retrieval'
     standalone: true
 })
 export class RouteMapRoutePipe implements PipeTransform {
-    public transform(route: RouteMapRoute, ...interpolationParams: Array<unknown>): string {
+    public transform(route: RouteMapRoute, interpolationParams: Params): string {
         return interpolateRoutePath(route, interpolationParams)
     }
 }

--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.pipe.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core'
+import { Params } from '@angular/router'
 import { RouteMapRoute } from '../route-map-route'
 import { interpolateRoutePath } from '../route-retrieval'
-import { Params } from '@angular/router'
 
 /**
  * Gets the fully interpolated path for the given route.

--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.spec.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-route.spec.ts
@@ -12,7 +12,7 @@ describe('RouteMapRoutePipe', () => {
         const listRoute: RouteMapRoute = { __path: 'students', __isContainer: false }
         const detailRoute: RouteMapRoute = { __path: ':id', __parent: listRoute, __isContainer: false }
 
-        expect(pipe.transform(detailRoute)).toBe('/students/undefined') // no value given for :id
-        expect(pipe.transform(detailRoute, 16)).toBe('/students/16')
+        expect(pipe.transform(detailRoute, {})).toBe('/students/:id') // no value given for :id
+        expect(pipe.transform(detailRoute, { id: 16 })).toBe('/students/16')
     })
 })

--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.pipe.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core'
+import { Params } from '@angular/router'
 import { RouteMapRoute } from '../route-map-route'
 import { interpolateRouteSegment } from '../route-retrieval'
-import { Params } from '@angular/router'
 
 /**
  * Gets the interpolated route segment for the given route.

--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.pipe.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.pipe.ts
@@ -1,6 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core'
 import { RouteMapRoute } from '../route-map-route'
 import { interpolateRouteSegment } from '../route-retrieval'
+import { Params } from '@angular/router'
 
 /**
  * Gets the interpolated route segment for the given route.
@@ -16,7 +17,7 @@ import { interpolateRouteSegment } from '../route-retrieval'
     standalone: true
 })
 export class RouteMapSegmentPipe implements PipeTransform {
-    public transform(route: RouteMapRoute, ...interpolationParams: Array<unknown>): string {
+    public transform(route: RouteMapRoute, interpolationParams: Params): string {
         return interpolateRouteSegment(route, interpolationParams)
     }
 }

--- a/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.spec.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/pipes/route-map-segment.spec.ts
@@ -12,7 +12,7 @@ describe('RouteMapSegmentPipe', () => {
         const listRoute: RouteMapRoute = { __path: 'students', __isContainer: false }
         const detailRoute: RouteMapRoute = { __path: ':id', __parent: listRoute, __isContainer: false }
 
-        expect(pipe.transform(detailRoute)).toBe('undefined') // no value given for :id
-        expect(pipe.transform(detailRoute, 16)).toBe('16')
+        expect(pipe.transform(detailRoute, {})).toBe(':id') // no value given for :id
+        expect(pipe.transform(detailRoute, { id: 16 })).toBe('16')
     })
 })

--- a/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.spec.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.spec.ts
@@ -61,7 +61,7 @@ describe('Route Retrieval Functions', () => {
     describe('interpolateRouteSegment', () => {
         it('should replace parameters in the path segment', () => {
             const route = defineRoute('users/:userId/posts/:postId')
-            const result = interpolateRouteSegment(route, [123, 456])
+            const result = interpolateRouteSegment(route, { userId: 123, postId: 456 })
             expect(result).toBe('users/123/posts/456')
         })
 
@@ -73,7 +73,7 @@ describe('Route Retrieval Functions', () => {
 
         it('should throw an error when interpolating a container route', () => {
             const container = defineContainer('users/:userId')
-            expect(() => interpolateRouteSegment(container, [123])).toThrow(
+            expect(() => interpolateRouteSegment(container, { userId: 123 })).toThrow(
                 new Error('Cannot interpolate path for a container route')
             )
         })
@@ -85,7 +85,7 @@ describe('Route Retrieval Functions', () => {
                 childRoute: defineRoute('users/:userId')
             })
 
-            const result = interpolateRoutePath(rootRoute.childRoute, [123])
+            const result = interpolateRoutePath(rootRoute.childRoute, { userId: 123 })
             expect(result).toBe('/api/users/123')
         })
 
@@ -94,7 +94,7 @@ describe('Route Retrieval Functions', () => {
                 childRoute: defineRoute('users/:userId')
             })
 
-            const result = interpolateRoutePath(rootRoute.childRoute, [123], { includeLeadingSlash: false })
+            const result = interpolateRoutePath(rootRoute.childRoute, { userId: 123 }, { includeLeadingSlash: false })
             expect(result).toBe('api/users/123')
         })
 
@@ -105,7 +105,7 @@ describe('Route Retrieval Functions', () => {
                 })
             })
 
-            const result = interpolateRoutePath(rootRoute.childRoute.grandChildRoute, [123, 456])
+            const result = interpolateRoutePath(rootRoute.childRoute.grandChildRoute, { userId: 123, postId: 456 })
             expect(result).toBe('/api/users/123/posts/456')
         })
 
@@ -124,7 +124,7 @@ describe('Route Retrieval Functions', () => {
                 childRoute: defineRoute('users/:userId')
             })
 
-            const result = interpolateRoutePath(container.childRoute, [123])
+            const result = interpolateRoutePath(container.childRoute, { userId: 123 })
             expect(result).toBe('/api/users/123')
         })
 
@@ -135,7 +135,7 @@ describe('Route Retrieval Functions', () => {
                 })
             })
 
-            const result = interpolateRoutePath(container.childRoute.grandChildRoute, [123, 456])
+            const result = interpolateRoutePath(container.childRoute.grandChildRoute, { userId: 123, postId: 456 })
             expect(result).toBe('/api/users/123/posts/456')
         })
     })

--- a/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.ts
@@ -1,4 +1,5 @@
 import { RouteMapRoute } from './route-map-route'
+import { Params } from '@angular/router'
 
 /**
  * Options for route path generation.
@@ -49,24 +50,26 @@ export const getFullRoutePath = (route: RouteMapRoute, options: RoutePathOptions
 
 /**
  * Gets the route segment for the given route map route and replaces the parameters with the provided values.
- * The parameters are expected to be in the same order as they appear in the path.
+ * The parameters are expected to have properties matching the names of the path parameters.
  * @param route The route to get the path for.
  * @param interpolationParams The values for the parameters to replace in the path.
  * @throws Error if the route is a container
  */
-export const interpolateRouteSegment = (route: RouteMapRoute, interpolationParams: Array<unknown>): string => {
+export const interpolateRouteSegment = (route: RouteMapRoute, interpolationParams: Params): string => {
     if (route.__isContainer) {
         throw new Error('Cannot interpolate path for a container route')
     }
 
-    const path = getRouteSegment(route)
-    const params = [...interpolationParams]
-    return path.replace(/:\w+/g, () => `${params.shift()}`)
+    let path = getRouteSegment(route)
+    Object.keys(interpolationParams).forEach((key) => {
+        path = path.replace(`:${key}`, interpolationParams[key])
+    })
+    return path
 }
 
 /**
  * Gets the route segment for the given route map route and replaces the parameters with the provided values.
- * The parameters are expected to be in the same order as they appear in the path.
+ * The parameters are expected to have properties matching the names of the path parameters.
  * @param route The route to get the path for.
  * @param interpolationParams The values for the parameters to replace in the path.
  * @param options Optional configuration for path generation.
@@ -74,14 +77,16 @@ export const interpolateRouteSegment = (route: RouteMapRoute, interpolationParam
  */
 export const interpolateRoutePath = (
     route: RouteMapRoute,
-    interpolationParams: Array<unknown>,
+    interpolationParams: Params,
     options: RoutePathOptions = {}
 ): string => {
     if (route.__isContainer) {
         throw new Error('Cannot interpolate path for a container route')
     }
 
-    const path = getFullRoutePath(route, { ...options, skipContainerCheck: true })
-    const params = [...interpolationParams]
-    return path.replace(/:\w+/g, () => `${params.shift()}`)
+    let path = getFullRoutePath(route, { ...options, skipContainerCheck: true })
+    Object.keys(interpolationParams).forEach((key) => {
+        path = path.replace(`:${key}`, interpolationParams[key])
+    })
+    return path
 }

--- a/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.ts
+++ b/projects/ppwcode/ng-router/src/lib/route-map/route-retrieval.ts
@@ -1,5 +1,5 @@
-import { RouteMapRoute } from './route-map-route'
 import { Params } from '@angular/router'
+import { RouteMapRoute } from './route-map-route'
 
 /**
  * Options for route path generation.


### PR DESCRIPTION
The router Params are really just an object, but this approach has (IMO) some advantages over passing in an array of values:

- Parameters no longer have to be in the order they appear in the path
- Can use the Params object from the ActivatedRoute snapshot to quickly interpolate the current route
- Descriptive name for each parameter since it's a property of an object now


This does mean that it's no longer possible to call interpolateRoutePath without providing parameters, but routes without parameters shouldn't need interpolating anyway, right?