### PR TITLE
Remove wireframe drawer content margin when the sidenav is forcibly closed because of no navigation items

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.html
@@ -30,7 +30,7 @@
     }
     <mat-drawer-content
         class="ppw-app-drawer-content"
-        [class.drawer-content-no-margin]="!!sidebarOptions()?.closedByDefaultOnLargerDevice"
+        [class.drawer-content-no-margin]="!!sidebarOptions()?.closedByDefaultOnLargerDevice || forceHiddenSidenav()"
     >
         <div class="ppw-page-container">
             @if (showWireframe()) {


### PR DESCRIPTION
This pull request updates the behavior of the `wireframe.component.html` file to account for an additional condition when determining the `drawer-content-no-margin` class. 

Key change:

* Modified the `mat-drawer-content` element to include the `forceHiddenSidenav()` method as part of the condition for applying the `drawer-content-no-margin` class. This ensures the class is applied not only when `sidebarOptions()?.closedByDefaultOnLargerDevice` is true but also when the `forceHiddenSidenav()` method returns true.

Fixes #54 