### PR TITLE
feat(router): provide pagination options to specify the router behavior when the page changes

### DIFF
--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination-options.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination-options.ts
@@ -11,6 +11,13 @@ export interface PaginationOptions {
      * This defaults to `false`, meaning that the URL query parameters will be visible in the URL.
      */
     skipLocationChange?: boolean
+    /**
+     * This defaults to `false`, meaning you want to add a new entry to the history stack instead of replacing the current one,
+     * meaning that the user navigates to the previous page of the data set in the table when using the back button.
+     * Set this to `true` when the state in history should be replaced with the new URL.
+     * It ensures that the user navigates to the previous page of the application when using the back button.
+     */
+    replaceUrl?: boolean
 }
 
 /** Injection token for the pagination options. */

--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination-options.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination-options.ts
@@ -1,0 +1,30 @@
+import { InjectionToken, ValueProvider } from '@angular/core'
+
+/**
+ * Interface describing the default options for pagination within the application.
+ */
+export interface PaginationOptions {
+    /**
+     * Enable this when you don't want the URL to change when navigating to a different page in the data set.
+     * This is useful for when you don't want the URL to contain the page and page size parameters and ensures
+     * that the first page of the data set is show again when refreshing the browser page.
+     * This defaults to `false`, meaning that the URL query parameters will be visible in the URL.
+     */
+    skipLocationChange?: boolean
+}
+
+/** Injection token for the pagination options. */
+export const PAGINATION_OPTIONS: InjectionToken<PaginationOptions> = new InjectionToken<PaginationOptions>(
+    'Pagination options'
+)
+
+/**
+ * Provides the default pagination options for the application.
+ * @param options The pagination options to provide.
+ */
+export const providePaginationOptions = (options: PaginationOptions): ValueProvider => {
+    return {
+        provide: PAGINATION_OPTIONS,
+        useValue: options
+    }
+}

--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
@@ -3,6 +3,8 @@ import { distinctUntilChanged, map, Observable } from 'rxjs'
 import { watchNumberQueryParam } from '../routing'
 import { Constructor } from '@ppwcode/ng-common'
 import { RelativeNavigationCtor } from '../relative-navigation'
+import { inject } from '@angular/core'
+import { PAGINATION_OPTIONS, PaginationOptions } from './pagination-options'
 
 /**
  * Interface describing something that supports pagination.
@@ -37,6 +39,8 @@ export type CanPageCtor = Constructor<CanPage>
  */
 export const mixinPagination = <T extends RelativeNavigationCtor>(base: T): T & CanPageCtor => {
     return class extends base implements CanPage {
+        readonly #defaultOptions: PaginationOptions = inject(PAGINATION_OPTIONS, { optional: true }) ?? {}
+
         public page$ = this.watchPageIndexParam('page')
         public pageSize$ = this.watchPageSizeParam('pageSize')
         public defaultPageSize = 20
@@ -64,7 +68,8 @@ export const mixinPagination = <T extends RelativeNavigationCtor>(base: T): T & 
                 queryParams: {
                     [queryParamName]: page
                 },
-                queryParamsHandling: 'merge'
+                queryParamsHandling: 'merge',
+                skipLocationChange: this.#defaultOptions.skipLocationChange ?? false
             })
         }
     }

--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
@@ -69,7 +69,8 @@ export const mixinPagination = <T extends RelativeNavigationCtor>(base: T): T & 
                     [queryParamName]: page
                 },
                 queryParamsHandling: 'merge',
-                skipLocationChange: this.#defaultOptions.skipLocationChange ?? false
+                skipLocationChange: this.#defaultOptions.skipLocationChange ?? false,
+                replaceUrl: this.#defaultOptions.replaceUrl ?? false
             })
         }
     }

--- a/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
+++ b/projects/ppwcode/ng-router/src/lib/mixins/pagination.ts
@@ -12,6 +12,8 @@ export interface CanPage {
     page$: Observable<number>
     /** The number of items on a single page. */
     pageSize$: Observable<number>
+    /** The default page size to use when no page size is specified. */
+    defaultPageSize: number
 
     /** Handler for when the page should be changed. */
     handlePageEvent(e: PageEvent, queryParamName?: string): Promise<void>

--- a/projects/ppwcode/ng-router/src/public-api.ts
+++ b/projects/ppwcode/ng-router/src/public-api.ts
@@ -4,6 +4,7 @@
 
 export * from './lib/routing'
 export * from './lib/relative-navigation'
+export { PaginationOptions, providePaginationOptions } from './lib/mixins/pagination-options'
 export * from './lib/mixins/pagination'
 export * from './lib/translated-page-title-strategy'
 export * from './lib/route-map/testing/get-full-route-map-urls'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,7 +81,9 @@ const ppwcodeComponents = [WireframeComponent]
             }
         }),
         providePaginationOptions({
-            skipLocationChange: true
+            // Defaults
+            skipLocationChange: false,
+            replaceUrl: true
         }),
         provideHttpClient(withInterceptorsFromDi()),
         provideTranslateService({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import { provideTranslateHttpLoader } from '@ngx-translate/http-loader'
 import { PPW_ASYNC_RESULT_DEFAULT_OPTIONS, PpwAsyncResultDefaultOptions } from '@ppwcode/ng-async'
 import { provideGlobalErrorHandler } from '@ppwcode/ng-common'
 import { PPW_TABLE_DEFAULT_OPTIONS } from '@ppwcode/ng-common-components'
-import { TranslatedPageTitleStrategy } from '@ppwcode/ng-router'
+import { providePaginationOptions, TranslatedPageTitleStrategy } from '@ppwcode/ng-router'
 import { WireframeComponent } from '@ppwcode/ng-wireframe'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
@@ -79,6 +79,9 @@ const ppwcodeComponents = [WireframeComponent]
                     singleErrorDetails: 'global-error-dialog.single-error-details'
                 }
             }
+        }),
+        providePaginationOptions({
+            skipLocationChange: true
         }),
         provideHttpClient(withInterceptorsFromDi()),
         provideTranslateService({

--- a/src/app/table/table-demo.component.ts
+++ b/src/app/table/table-demo.component.ts
@@ -138,8 +138,7 @@ export class TableDemoComponent
     implements OnInit
 {
     // Below variable is an override of the defaultPageSize property in the mixinPagination
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public defaultPageSize = 5
+    public override defaultPageSize = 5
     public enableRowDrag = false
     public enableAnimations = true
     public searchForm!: FormGroup


### PR DESCRIPTION
This PR adds a new function `providePaginationOptions` that can be used to specify the browser behavior when the page of the table changes.

* skipLocationChange
  * Enable this when you don't want the URL to change when navigating to a different page in the data set. This is useful for when you don't want the URL to contain the page and page size parameters and ensures that the first page of the data set is show again when refreshing the browser page. This defaults to `false`, meaning that the URL query parameters will be visible in the URL.
* replaceUrl
  * This default to `true`, meaning that the state in history will be replaced with the new URL. It ensures that the user navigates to the previous page of the application when using the back button. Set this to `false` when you want to add a new entry to the history stack instead of replacing the current one, meaning that the user navigates to the previous page of the data set in the table when using the back button.

## Breaking

This PR is a breaking change because of the default value for `replaceUrl`. In v19 of the SDK, this option is not provided, meaning that the url is not replaced when updating the query params and thus adding an extra entry in the browser history. After merging this PR for v20, the default will be replacement of the history state which means that users using the browser back button will then be returned to the previous page of the browser instead of the previous page of the table.

Closes #16 