### PR TITLE
fix(components): ensure dashboard-items-table is compatible with both FontAwesome v6 and v7

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/dashboard-items/dashboard-items-table/dashboard-items-table.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/dashboard-items/dashboard-items-table/dashboard-items-table.component.scss
@@ -48,6 +48,7 @@
                 color: var(--ppw-dashboard-items-table-primary-color);
                 background-color: var(--ppw-dashboard-items-table-background-color);
                 cursor: pointer;
+                width: calc(100% - 64px);
 
                 &:focus,
                 &:active,
@@ -160,6 +161,7 @@
 
                 .ppw-dashboard-card-image {
                     padding: 32px 0 32px 0;
+                    width: 100%;
                 }
             }
         }
@@ -194,6 +196,7 @@
                 .ppw-dashboard-card-image {
                     padding: 16px 0 16px 0;
                     font-size: 60px;
+                    width: 100%;
                 }
             }
         }


### PR DESCRIPTION
**FontAwesome v6, taken before the change**
<img width="1710" height="1007" alt="image" src="https://github.com/user-attachments/assets/390c11ee-348f-46ea-a946-ef2aa64fe97c" />

**FontAwesome v7, taken after the change**
<img width="1716" height="999" alt="image" src="https://github.com/user-attachments/assets/5d2a019c-c086-47d0-903b-1518acea9966" />

Closes #65 