### PR TITLE
fix(common-components): dashboard items were stretching to wide

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/dashboard-items/dashboard-items-table/dashboard-items-table.component.scss
+++ b/projects/ppwcode/ng-common-components/src/lib/dashboard-items/dashboard-items-table/dashboard-items-table.component.scss
@@ -20,7 +20,7 @@
 
     .ppw-dashboard-wrapper {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
         gap: 16px;
 
         mat-card.dashboard-item {


### PR DESCRIPTION
Update the dashboard items grid to auto-fill instead of auto-fit. This ensures that the dashboard cards aren't stretched too much