### PR TITLE
perf(common-components): improve performance of table selection

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/table/form-table.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/table/form-table.component.ts
@@ -28,8 +28,11 @@ export class FormTableComponent<TRecord> extends AbstractTableComponent<TRecord>
      */
     protected _mapToLocalKeyValuePairs(
         items: FormArray<FormGroup>,
-        columns: Array<Column<TRecord, unknown>>
+        columns: Array<Column<TRecord, unknown>>,
+        disabledFn?: (record: TRecord) => boolean
     ): Array<TableRecord<TRecord>> {
+        disabledFn ??= () => false
+
         const records: FormGroup[] = items.controls ?? []
 
         return records.map((record, index) => {
@@ -42,7 +45,8 @@ export class FormTableComponent<TRecord> extends AbstractTableComponent<TRecord>
             return {
                 initialRecord: record,
                 mappedValues,
-                trackByValue: this.trackBy()(index, record as TRecord)
+                trackByValue: this.trackBy()(index, record as TRecord),
+                selectable: !disabledFn(record as TRecord)
             } as TableRecord<TRecord>
         })
     }

--- a/projects/ppwcode/ng-common-components/src/lib/table/models/table-record.model.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/table/models/table-record.model.ts
@@ -5,4 +5,6 @@ export interface TableRecord<T = unknown> {
     mappedValues: Record<string, unknown>
     /** The value generated for the trackBy function. */
     trackByValue: unknown
+    /** Whether the record can be selected. */
+    selectable: boolean
 }

--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
@@ -41,7 +41,7 @@
                 <th mat-header-cell *matHeaderCellDef>
                     <mat-checkbox
                         color="primary"
-                        [disabled]="dataSource().data.length === 0"
+                        [disabled]="selectableRows().length === 0"
                         [style.width]="options()?.columns?.widths?.['rowSelection']"
                         (change)="$event ? masterToggle() : null"
                         [checked]="isAllSelected()"
@@ -55,7 +55,7 @@
                         [style.width]="options()?.columns?.widths?.['rowSelection']"
                         (change)="$event ? selection.toggle(row) : null"
                         [checked]="selection.isSelected(row)"
-                        [disabled]="isRowSelectionDisabled(row)"
+                        [disabled]="!row.selectable"
                     >
                     </mat-checkbox>
                 </td>

--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.ts
@@ -30,8 +30,11 @@ export class TableComponent<TRecord>
      */
     protected _mapToLocalKeyValuePairs(
         items: Array<Record<string, unknown>>,
-        columns: Array<Column<TRecord, unknown>>
+        columns: Array<Column<TRecord, unknown>>,
+        disabledFn?: (record: TRecord) => boolean
     ): Array<TableRecord<TRecord>> {
+        disabledFn ??= () => false
+
         const records: Array<Record<string, unknown>> = items ?? []
 
         return records.map((record, index) => {
@@ -44,7 +47,8 @@ export class TableComponent<TRecord>
             return {
                 initialRecord: record,
                 mappedValues,
-                trackByValue: this.trackBy()(index, record as TRecord)
+                trackByValue: this.trackBy()(index, record as TRecord),
+                selectable: !disabledFn(record as TRecord)
             } as TableRecord<TRecord>
         })
     }


### PR DESCRIPTION
Converting this to use computed signals, ensures that the disabledFn doesn't get called too often and only when necessary.