### PR TITLE
When the error text is 'DB_UQ_CONSTRAINT_VIOLATION', the parameters l…

### DIFF
--- a/projects/ppwcode/ng-async/src/lib/error-handling.spec.ts
+++ b/projects/ppwcode/ng-async/src/lib/error-handling.spec.ts
@@ -81,7 +81,7 @@ describe('extractHttpError', () => {
         })
 
         const error = extractHttpError(httpError)
-        expect(error.message).toBe('DB_UQ_CONSTRAINT_VIOLATION')
+        expect(error.message).toBe('other_param')
     })
 
     it('should extract title from error object', () => {

--- a/projects/ppwcode/ng-async/src/lib/error-handling.ts
+++ b/projects/ppwcode/ng-async/src/lib/error-handling.ts
@@ -27,7 +27,7 @@ export const extractHttpError = (httpError: HttpErrorResponse, skipCustomExtract
         if (Array.isArray(httpError.error.messages) && httpError.error.messages.length > 0) {
             const firstErrorMessage = httpError.error.messages[0]
             if (firstErrorMessage.text === 'DB_UQ_CONSTRAINT_VIOLATION') {
-                const parameter = firstErrorMessage.parameters?.find((param: string) => param.startsWith('UQ_'))
+                const parameter = firstErrorMessage.parameters.length > 0 ? firstErrorMessage.parameters[0] : null
                 if (parameter) {
                     return new Error(parameter)
                 } else {


### PR DESCRIPTION
When the error text is 'DB_UQ_CONSTRAINT_VIOLATION', the parameters list first element should always be shown as the error message.
This helps indicating the real error when an end user shows a screenshot with the error toast in it.