### PR TITLE
Disable row drag when enableRowDrag is false

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
@@ -157,6 +157,7 @@
         <tr
             mat-row
             cdkDrag
+            [cdkDragDisabled]="!enableRowDrag()"
             *matRowDef="let row; columns: columnNames()"
             [class.ppw-table-row-enter]="!disableAnimations()"
             [class.highlight]="options()?.rows?.highlightOnHover"


### PR DESCRIPTION
Even when row dragging was disabled, users still could drag rows. In this PR I make sure they can't.