### PR TITLE
bugfix(ng-common-components) Fix combined usage of table footer row and expandable rows.

### DIFF
--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.html
@@ -132,6 +132,9 @@
                         <mat-icon>keyboard_arrow_down</mat-icon>
                     </button>
                 </td>
+                @if (footerData() !== undefined) {
+                    <td mat-footer-cell *matFooterCellDef></td>
+                }
             </ng-container>
             <ng-container matColumnDef="expandedDetail">
                 <td mat-cell *matCellDef="let record" [attr.colspan]="columnNames().length">
@@ -173,10 +176,7 @@
             <tr mat-footer-row *matFooterRowDef="columnNames(); sticky: !!options()?.header?.sticky"></tr>
         }
         <tr *matNoDataRow>
-            <td
-                [attr.colspan]="columnNames().length + (enableRowSelection() ? 1 : 0) + (enableRowDrag() ? 1 : 0)"
-                class="ppw-table-no-data-row"
-            >
+            <td [attr.colspan]="columnNames().length" class="ppw-table-no-data-row">
                 @if (emptyPageTemplate(); as empty) {
                     <ng-container *ngTemplateOutlet="empty"></ng-container>
                 } @else if (emptyPageComponent) {

--- a/projects/ppwcode/ng-common-components/src/lib/table/table.component.spec.ts
+++ b/projects/ppwcode/ng-common-components/src/lib/table/table.component.spec.ts
@@ -92,7 +92,13 @@ export function getJsDateFormatter(): (value: Date) => string {
 
 @Component({
     template: `
-        <ppw-table [data]="data()" [trackBy]="trackBy">
+        <ppw-table
+            [data]="data()"
+            [trackBy]="trackBy"
+            [footerData]="footerData()"
+            [expandable]="expandable()"
+            [expandableTemplate]="expandableTemplate"
+        >
             @for (column of columns(); track column) {
                 <ppw-column
                     [name]="column.name"
@@ -103,6 +109,10 @@ export function getJsDateFormatter(): (value: Date) => string {
                     [disableSortClear]="column.disableSortClear"
                 ></ppw-column>
             }
+
+            <ng-template #expandableTemplate let-record>
+                <div class="expanded-content">Expanded {{ record.name }}</div>
+            </ng-template>
         </ppw-table>
     `,
     imports: [PpwTableModule],
@@ -126,6 +136,8 @@ class TestTableComponent {
     ])
     public data: WritableSignal<Array<PeriodicElement>> = signal(MOCK_ELEMENT_DATA)
     public trackBy = (index: number, record: PeriodicElement) => record.position
+    public footerData: WritableSignal<Record<string, unknown> | undefined> = signal(undefined)
+    public expandable: WritableSignal<boolean> = signal(false)
 }
 
 describe('TableComponent', () => {
@@ -149,6 +161,22 @@ describe('TableComponent', () => {
         expect(tableComponent.dataSource().data[3].initialRecord).toBe(testData)
         expect(tableComponent.dataSource().data[3].mappedValues['elementName']).toBe('Beryllium')
         expect(tableComponent.dataSource().data[3].mappedValues['symbol']).toBe('Be')
+    })
+
+    it('should not crash when both expandable and footerData are enabled', async () => {
+        fixture.componentInstance.expandable.set(true)
+        fixture.componentInstance.footerData.set({
+            elementName: 'Total',
+            symbol: 'ALL'
+        })
+        fixture.detectChanges()
+        await fixture.whenStable()
+
+        expect(tableComponent.columnNames()).toContain('expand')
+        const table = fixture.nativeElement.querySelector('table')
+        expect(table).toBeTruthy()
+        const rows = fixture.nativeElement.querySelectorAll('tr')
+        expect(rows.length).toBeGreaterThan(0)
     })
 
     it('should detect column changes', async () => {


### PR DESCRIPTION
The table component crashes when a table with expandable rows is used in combination with a footer row. This PR fixes this.