### PR TITLE
Set up `ng-e2e-testing` library with accessibility testing utilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,5 @@ jobs:
             - run: npm run ci:lint
             - run: npm run ci:build-libs
             - run: npm run ci:test-libs
+            - run: npx playwright install --with-deps chromium
+            - run: npm run ci:test-e2e

--- a/angular.json
+++ b/angular.json
@@ -28,10 +28,10 @@
                             "src/assets"
                         ],
                         "styles": [
-                          "@angular/material/prebuilt-themes/purple-green.css",
-                          "node_modules/@fortawesome/fontawesome-free/css/fontawesome.min.css",
-                          "node_modules/@fortawesome/fontawesome-free/css/all.min.css",
-                          "src/styles.scss"
+                            "@angular/material/prebuilt-themes/purple-green.css",
+                            "node_modules/@fortawesome/fontawesome-free/css/fontawesome.min.css",
+                            "node_modules/@fortawesome/fontawesome-free/css/all.min.css",
+                            "src/styles.scss"
                         ],
                         "scripts": []
                     },
@@ -64,10 +64,10 @@
                     "builder": "@angular/build:dev-server",
                     "configurations": {
                         "production": {
-                          "buildTarget": "ppwcode:build:production"
+                            "buildTarget": "ppwcode:build:production"
                         },
                         "development": {
-                          "buildTarget": "ppwcode:build:development"
+                            "buildTarget": "ppwcode:build:development"
                         }
                     },
                     "defaultConfiguration": "development"
@@ -75,7 +75,7 @@
                 "extract-i18n": {
                     "builder": "@angular/build:extract-i18n",
                     "options": {
-                      "buildTarget": "ppwcode:build"
+                        "buildTarget": "ppwcode:build"
                     }
                 },
                 "test": {
@@ -409,124 +409,147 @@
             }
         },
         "@ppwcode/ng-common-components": {
-          "projectType": "library",
-          "root": "projects/ppwcode/ng-common-components",
-          "sourceRoot": "projects/ppwcode/ng-common-components/src",
-          "prefix": "lib",
-          "architect": {
-            "build": {
-              "builder": "@angular/build:ng-packagr",
-              "options": {
-                "project": "projects/ppwcode/ng-common-components/ng-package.json"
-              },
-              "configurations": {
-                "production": {
-                  "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.lib.prod.json"
+            "projectType": "library",
+            "root": "projects/ppwcode/ng-common-components",
+            "sourceRoot": "projects/ppwcode/ng-common-components/src",
+            "prefix": "lib",
+            "architect": {
+                "build": {
+                    "builder": "@angular/build:ng-packagr",
+                    "options": {
+                        "project": "projects/ppwcode/ng-common-components/ng-package.json"
+                    },
+                    "configurations": {
+                        "production": {
+                            "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.lib.prod.json"
+                        },
+                        "development": {
+                            "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.lib.json"
+                        }
+                    },
+                    "defaultConfiguration": "production"
                 },
-                "development": {
-                  "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.lib.json"
+                "test": {
+                    "builder": "@angular/build:unit-test",
+                    "options": {
+                        "runnerConfig": "vitest.config.ts",
+                        "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.spec.json"
+                    }
                 }
-              },
-              "defaultConfiguration": "production"
-            },
-            "test": {
-              "builder": "@angular/build:unit-test",
-              "options": {
-                "runnerConfig": "vitest.config.ts",
-                "tsConfig": "projects/ppwcode/ng-common-components/tsconfig.spec.json"
-              }
             }
-          }
         },
         "@ppwcode/ng-unit-testing": {
-          "projectType": "library",
-          "root": "projects/ppwcode/ng-unit-testing",
-          "sourceRoot": "projects/ppwcode/ng-unit-testing/src",
-          "prefix": "lib",
-          "architect": {
-            "build": {
-              "builder": "@angular/build:ng-packagr",
-              "options": {
-                "project": "projects/ppwcode/ng-unit-testing/ng-package.json"
-              },
-              "configurations": {
-                "production": {
-                  "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.lib.prod.json"
+            "projectType": "library",
+            "root": "projects/ppwcode/ng-unit-testing",
+            "sourceRoot": "projects/ppwcode/ng-unit-testing/src",
+            "prefix": "lib",
+            "architect": {
+                "build": {
+                    "builder": "@angular/build:ng-packagr",
+                    "options": {
+                        "project": "projects/ppwcode/ng-unit-testing/ng-package.json"
+                    },
+                    "configurations": {
+                        "production": {
+                            "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.lib.prod.json"
+                        },
+                        "development": {
+                            "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.lib.json"
+                        }
+                    },
+                    "defaultConfiguration": "production"
                 },
-                "development": {
-                  "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.lib.json"
+                "test": {
+                    "builder": "@angular/build:unit-test",
+                    "options": {
+                        "runnerConfig": "vitest.config.ts",
+                        "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.spec.json"
+                    }
                 }
-              },
-              "defaultConfiguration": "production"
-            },
-            "test": {
-              "builder": "@angular/build:unit-test",
-              "options": {
-                "runnerConfig": "vitest.config.ts",
-                "tsConfig": "projects/ppwcode/ng-unit-testing/tsconfig.spec.json"
-              }
             }
-          }
         },
         "@ppwcode/ng-sdk": {
-          "projectType": "library",
-          "root": "projects/ppwcode/ng-sdk",
-          "sourceRoot": "projects/ppwcode/ng-sdk/src",
-          "prefix": "lib",
-          "architect": {
-            "build": {
-              "builder": "@angular/build:ng-packagr",
-              "configurations": {
-                "production": {
-                  "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.lib.prod.json"
+            "projectType": "library",
+            "root": "projects/ppwcode/ng-sdk",
+            "sourceRoot": "projects/ppwcode/ng-sdk/src",
+            "prefix": "lib",
+            "architect": {
+                "build": {
+                    "builder": "@angular/build:ng-packagr",
+                    "configurations": {
+                        "production": {
+                            "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.lib.prod.json"
+                        },
+                        "development": {
+                            "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.lib.json"
+                        }
+                    },
+                    "defaultConfiguration": "production"
                 },
-                "development": {
-                  "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.lib.json"
+                "test": {
+                    "builder": "@angular/build:unit-test",
+                    "options": {
+                        "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.spec.json"
+                    }
                 }
-              },
-              "defaultConfiguration": "production"
-            },
-            "test": {
-              "builder": "@angular/build:unit-test",
-              "options": {
-                "tsConfig": "projects/ppwcode/ng-sdk/tsconfig.spec.json"
-              }
             }
-          }
+        },
+        "@ppwcode/ng-e2e-testing": {
+            "projectType": "library",
+            "root": "projects/ppwcode/ng-e2e-testing",
+            "sourceRoot": "projects/ppwcode/ng-e2e-testing/src",
+            "prefix": "lib",
+            "architect": {
+                "build": {
+                    "builder": "@angular/build:ng-packagr",
+                    "options": {
+                        "project": "projects/ppwcode/ng-e2e-testing/ng-package.json"
+                    },
+                    "configurations": {
+                        "production": {
+                            "tsConfig": "projects/ppwcode/ng-e2e-testing/tsconfig.lib.prod.json"
+                        },
+                        "development": {
+                            "tsConfig": "projects/ppwcode/ng-e2e-testing/tsconfig.lib.json"
+                        }
+                    },
+                    "defaultConfiguration": "production"
+                }
+            }
         }
     },
     "cli": {
-      "analytics": false
+        "analytics": false
     },
     "schematics": {
-      "@schematics/angular:component": {
-        "type": "component"
-      },
-      "@schematics/angular:directive": {
-        "type": "directive"
-      },
-      "@schematics/angular:service": {
-        "type": "service"
-      },
-      "@schematics/angular:guard": {
-        "typeSeparator": "."
-      },
-      "@schematics/angular:interceptor": {
-        "typeSeparator": "."
-      },
-      "@schematics/angular:module": {
-        "typeSeparator": "."
-      },
-      "@schematics/angular:pipe": {
-        "typeSeparator": "."
-      },
-      "@schematics/angular:resolver": {
-        "typeSeparator": "."
-      },
-      "@schematics/angular": {
-        "component": {
-          "changeDetection": "OnPush"
+        "@schematics/angular:component": {
+            "type": "component"
+        },
+        "@schematics/angular:directive": {
+            "type": "directive"
+        },
+        "@schematics/angular:service": {
+            "type": "service"
+        },
+        "@schematics/angular:guard": {
+            "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+            "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+            "typeSeparator": "."
+        },
+        "@schematics/angular:pipe": {
+            "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+            "typeSeparator": "."
+        },
+        "@schematics/angular": {
+            "component": {
+                "changeDetection": "OnPush"
+            }
         }
-      }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
                 "@angular/build": "22.0.1",
                 "@angular/cli": "22.0.1",
                 "@angular/compiler-cli": "22.0.1",
+                "@axe-core/playwright": "4.12.1",
+                "@playwright/test": "1.61.1",
                 "@schematics/angular": "21.2.3",
                 "@types/file-saver-es": "2.0.1",
                 "@types/node": "22.13.14",
@@ -1771,6 +1773,19 @@
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+            "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "axe-core": "~4.12.1"
+            },
+            "peerDependencies": {
+                "playwright-core": ">= 1.0.0"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -4516,6 +4531,22 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@rollup/plugin-json": {
             "version": "6.1.0",
@@ -10787,6 +10818,53 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
         "@angular/build": "22.0.1",
         "@angular/cli": "22.0.1",
         "@angular/compiler-cli": "22.0.1",
+        "@axe-core/playwright": "4.12.1",
+        "@playwright/test": "1.61.1",
         "@schematics/angular": "21.2.3",
         "@types/file-saver-es": "2.0.1",
         "@types/node": "22.13.14",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
         "lint:lint": "ng lint",
         "format:lint": "ng lint --fix",
         "ci:test-libs": "node ./scripts/ci/test-libs.js",
+        "ci:test-e2e": "node ./scripts/ci/test-e2e.js",
+        "e2e:ui": "node ./scripts/ci/test-e2e.js --ui",
         "ci:lint": "npm run lint:prettier && npm run lint:lint",
         "ci:build": "ng build ppwcode --base-href /angular-sdk/ --deploy-url /angular-sdk/",
         "ci:build-libs": "./scripts/ci/build-libs.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+    testDir: './src/app',
+    testMatch: '**/*.e2e-spec.ts',
+    fullyParallel: true,
+    forbidOnly: !!process.env['CI'],
+    retries: process.env['CI'] ? 2 : 0,
+    workers: process.env['CI'] ? 1 : undefined,
+    reporter: process.env['CI'] ? 'github' : 'list',
+    use: {
+        baseURL: 'http://127.0.0.1:4200/angular-sdk/',
+        trace: 'retain-on-failure'
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] }
+        }
+    ]
+})

--- a/projects/ppwcode/ng-e2e-testing/.eslintrc.json
+++ b/projects/ppwcode/ng-e2e-testing/.eslintrc.json
@@ -1,0 +1,44 @@
+{
+    "extends": "../../../.eslintrc.json",
+    "ignorePatterns": ["!**/*"],
+    "rules": {
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "@ppwcode/ng-e2e-testing",
+                        "message": "Use a relative import instead. Importing from @ppwcode/ng-e2e-testing is not allowed inside this lib directory."
+                    }
+                ]
+            }
+        ]
+    },
+    "overrides": [
+        {
+            "files": ["*.ts"],
+            "rules": {
+                "@angular-eslint/directive-selector": [
+                    "error",
+                    {
+                        "type": "attribute",
+                        "prefix": "ppw",
+                        "style": "camelCase"
+                    }
+                ],
+                "@angular-eslint/component-selector": [
+                    "error",
+                    {
+                        "type": "element",
+                        "prefix": "ppw",
+                        "style": "kebab-case"
+                    }
+                ]
+            }
+        },
+        {
+            "files": ["*.html"],
+            "rules": {}
+        }
+    ]
+}

--- a/projects/ppwcode/ng-e2e-testing/ng-package.json
+++ b/projects/ppwcode/ng-e2e-testing/ng-package.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../../dist/ppwcode/ng-e2e-testing",
+    "lib": {
+        "entryFile": "src/public-api.ts"
+    }
+}

--- a/projects/ppwcode/ng-e2e-testing/package.json
+++ b/projects/ppwcode/ng-e2e-testing/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@ppwcode/ng-e2e-testing",
+    "version": "0.0.1",
+    "repository": {
+        "url": "https://github.com/peopleware/angular-sdk"
+    },
+    "peerDependencies": {
+        "@axe-core/playwright": "^4.0.0",
+        "@playwright/test": "^1.0.0",
+        "axe-core": "^4.0.0"
+    },
+    "dependencies": {
+        "tslib": "^2.3.0"
+    },
+    "sideEffects": false
+}

--- a/projects/ppwcode/ng-e2e-testing/src/lib/a11y/axe.ts
+++ b/projects/ppwcode/ng-e2e-testing/src/lib/a11y/axe.ts
@@ -1,0 +1,45 @@
+import AxeBuilder from '@axe-core/playwright'
+import type { Page } from '@playwright/test'
+import type { AxeResults } from 'axe-core'
+
+/**
+ * The WCAG 2.0 A/AA, WCAG 2.1 A/AA and WCAG 2.2 A/AA rule tags — the accessibility compliance
+ * target for this application.
+ */
+export const WCAG_2_2_AA_TAGS: readonly string[] = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']
+
+/**
+ * Runs axe-core against the given Playwright page with WCAG 2.2 AA rules.
+ * Mirrors the unit-test helper so both layers stay aligned on what "accessible"
+ * means for this project.
+ *
+ * Usage in e2e specs:
+ *   const results = await analyzePage(page)
+ *   expectNoViolations(results)
+ */
+export function analyzePage(page: Page): Promise<AxeResults> {
+    return new AxeBuilder({ page }).withTags([...WCAG_2_2_AA_TAGS]).analyze()
+}
+
+/**
+ * Fails the current test with a formatted list of accessibility violations
+ * when `results.violations` is non-empty.
+ */
+export function expectNoViolations(results: AxeResults): void {
+    if (results.violations.length === 0) {
+        return
+    }
+
+    const details = results.violations
+        .map((violation) => {
+            const nodeList = violation.nodes
+                .map((node) => `      - ${node.target.join(', ')}\n        ${node.failureSummary ?? ''}`)
+                .join('\n')
+            return `  • [${violation.id}] ${violation.help} (${violation.impact ?? 'n/a'})\n    ${
+                violation.helpUrl
+            }\n${nodeList}`
+        })
+        .join('\n\n')
+
+    throw new Error(`Expected no accessibility violations but found ${results.violations.length}:\n\n${details}`)
+}

--- a/projects/ppwcode/ng-e2e-testing/src/lib/a11y/axe.ts
+++ b/projects/ppwcode/ng-e2e-testing/src/lib/a11y/axe.ts
@@ -1,5 +1,6 @@
 import AxeBuilder from '@axe-core/playwright'
-import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import type { AxeResults } from 'axe-core'
 
 /**
@@ -17,8 +18,14 @@ export const WCAG_2_2_AA_TAGS: readonly string[] = ['wcag2a', 'wcag2aa', 'wcag21
  *   const results = await analyzePage(page)
  *   expectNoViolations(results)
  */
-export function analyzePage(page: Page): Promise<AxeResults> {
-    return new AxeBuilder({ page }).withTags([...WCAG_2_2_AA_TAGS]).analyze()
+export function analyzePage(page: Page, options: { includeSelector?: string } = {}): Promise<AxeResults> {
+    let builder = new AxeBuilder({ page }).withTags([...WCAG_2_2_AA_TAGS])
+
+    if (options.includeSelector) {
+        builder = builder.include(options.includeSelector)
+    }
+
+    return builder.analyze()
 }
 
 /**
@@ -42,4 +49,25 @@ export function expectNoViolations(results: AxeResults): void {
         .join('\n\n')
 
     throw new Error(`Expected no accessibility violations but found ${results.violations.length}:\n\n${details}`)
+}
+
+/**
+ * Defines a Playwright test that opens a route, waits until the page is ready,
+ * and fails when axe reports WCAG 2.2 AA accessibility violations.
+ */
+export function verifyE2eA11y(options: {
+    name?: string
+    path: string
+    includeSelector: string
+    readyLocator: (page: Page) => Locator
+}): void {
+    test(options.name ?? `${options.path} has no WCAG 2.2 AA violations`, async ({ page }) => {
+        await page.goto(options.path)
+
+        await expect(options.readyLocator(page)).toBeVisible()
+
+        const results = await analyzePage(page, { includeSelector: options.includeSelector })
+
+        expectNoViolations(results)
+    })
 }

--- a/projects/ppwcode/ng-e2e-testing/src/public-api.ts
+++ b/projects/ppwcode/ng-e2e-testing/src/public-api.ts
@@ -1,0 +1,5 @@
+/*
+ * Public API Surface of ng-e2e-testing
+ */
+
+export * from './lib/a11y/axe'

--- a/projects/ppwcode/ng-e2e-testing/tsconfig.lib.json
+++ b/projects/ppwcode/ng-e2e-testing/tsconfig.lib.json
@@ -1,0 +1,12 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+    "extends": "../../../tsconfig.angular.json",
+    "compilerOptions": {
+        "outDir": "../../../out-tsc/lib",
+        "declaration": true,
+        "declarationMap": true,
+        "inlineSources": true,
+        "types": ["node"]
+    },
+    "exclude": ["**/*.spec.ts"]
+}

--- a/projects/ppwcode/ng-e2e-testing/tsconfig.lib.prod.json
+++ b/projects/ppwcode/ng-e2e-testing/tsconfig.lib.prod.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "declarationMap": false
+    },
+    "angularCompilerOptions": {
+        "compilationMode": "partial"
+    }
+}

--- a/scripts/ci/test-e2e.js
+++ b/scripts/ci/test-e2e.js
@@ -1,0 +1,118 @@
+const { spawn } = require('child_process')
+const http = require('http')
+const path = require('path')
+
+const isWindows = process.platform === 'win32'
+const serverUrl = 'http://127.0.0.1:4200/angular-sdk/'
+const commandExtension = isWindows ? '.cmd' : ''
+const nodeBinPath = path.join(__dirname, '..', '..', 'node_modules', '.bin')
+
+const ngCommand = path.join(nodeBinPath, `ng${commandExtension}`)
+const playwrightCommand = path.join(nodeBinPath, `playwright${commandExtension}`)
+const playwrightArgs = ['test', ...process.argv.slice(2)]
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+const quoteCommandPart = (commandPart) => `"${commandPart.replaceAll('"', '\\"')}"`
+
+const getSpawnOptions = (command, args) => {
+    if (!isWindows) {
+        return { command, args, shell: false }
+    }
+
+    return {
+        command: [command, ...args].map(quoteCommandPart).join(' '),
+        args: [],
+        shell: true
+    }
+}
+
+const isServerReady = () =>
+    new Promise((resolve) => {
+        const request = http.get(serverUrl, (response) => {
+            response.resume()
+            resolve(response.statusCode >= 200 && response.statusCode < 500)
+        })
+
+        request.on('error', () => resolve(false))
+        request.setTimeout(1000, () => {
+            request.destroy()
+            resolve(false)
+        })
+    })
+
+const waitForServer = async () => {
+    const deadline = Date.now() + 120_000
+
+    while (Date.now() < deadline) {
+        if (await isServerReady()) {
+            return
+        }
+
+        await wait(1000)
+    }
+
+    throw new Error(`Timed out waiting for ${serverUrl}`)
+}
+
+const runCommand = (command, args, options = {}) =>
+    new Promise((resolve) => {
+        const spawnOptions = getSpawnOptions(command, args)
+        const childProcess = spawn(spawnOptions.command, spawnOptions.args, {
+            stdio: 'inherit',
+            shell: spawnOptions.shell,
+            ...options
+        })
+
+        childProcess.on('exit', (code) => resolve(code ?? 1))
+        childProcess.on('error', (error) => {
+            console.error(error)
+            resolve(1)
+        })
+    })
+
+const killProcessTree = (processId) =>
+    new Promise((resolve) => {
+        if (isWindows) {
+            const taskkill = spawn('taskkill', ['/pid', processId.toString(), '/T', '/F'], {
+                stdio: 'ignore'
+            })
+            taskkill.on('exit', resolve)
+            taskkill.on('error', resolve)
+            return
+        }
+
+        try {
+            process.kill(-processId, 'SIGTERM')
+        } catch {
+            try {
+                process.kill(processId, 'SIGTERM')
+            } catch {
+                // The process has already exited.
+            }
+        }
+
+        resolve()
+    })
+
+const run = async () => {
+    const serverSpawnOptions = getSpawnOptions(ngCommand, ['serve', '--host', '127.0.0.1', '--port', '4200'])
+    const serverProcess = spawn(serverSpawnOptions.command, serverSpawnOptions.args, {
+        detached: !isWindows,
+        shell: serverSpawnOptions.shell,
+        stdio: 'inherit'
+    })
+
+    try {
+        await waitForServer()
+        process.exitCode = await runCommand(playwrightCommand, playwrightArgs)
+    } finally {
+        await killProcessTree(serverProcess.pid)
+    }
+}
+
+run()
+    .then(() => process.exit(process.exitCode ?? 0))
+    .catch((error) => {
+        console.error(error)
+        process.exit(1)
+    })

--- a/src/app/components-dashboard-demo/components-dashboard-demo.e2e-spec.ts
+++ b/src/app/components-dashboard-demo/components-dashboard-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'components dashboard demo has no WCAG 2.2 AA violations',
+    path: 'components',
+    includeSelector: 'ppw-components-dashboard-demo',
+    readyLocator: (page) => page.getByText('Confirmation Dialog')
+})

--- a/src/app/confirmation-dialog-demo/confirmation-dialog-demo.e2e-spec.ts
+++ b/src/app/confirmation-dialog-demo/confirmation-dialog-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'confirmation dialog demo has no WCAG 2.2 AA violations',
+    path: 'components/confirmation-dialog',
+    includeSelector: 'ppw-confirmation-dialog-demo',
+    readyLocator: (page) => page.getByRole('button', { name: 'Request confirmation' })
+})

--- a/src/app/dashboard-item-demo/dashboard-item-demo.e2e-spec.ts
+++ b/src/app/dashboard-item-demo/dashboard-item-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'dashboard item demo has no WCAG 2.2 AA violations',
+    path: 'dashboard-item',
+    includeSelector: 'ppw-dashboard-item-demo',
+    readyLocator: (page) => page.locator('mat-card-title', { hasText: 'Components' })
+})

--- a/src/app/editable-table/editable-table.e2e-spec.ts
+++ b/src/app/editable-table/editable-table.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'form table demo has no WCAG 2.2 AA violations',
+    path: 'components/form-table',
+    includeSelector: 'ppw-editable-table',
+    readyLocator: (page) => page.getByText('Current form array value:')
+})

--- a/src/app/expandable-card/expandable-card-demo.e2e-spec.ts
+++ b/src/app/expandable-card/expandable-card-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'expandable card demo has no WCAG 2.2 AA violations',
+    path: 'components/expandable-card',
+    includeSelector: 'ppw-expandable-card-demo',
+    readyLocator: (page) => page.getByText('Demo card which cannot be collapsed')
+})

--- a/src/app/global-error-handler/global-error-handler.e2e-spec.ts
+++ b/src/app/global-error-handler/global-error-handler.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'global error handler demo has no WCAG 2.2 AA violations',
+    path: 'global-error-handler',
+    includeSelector: 'ppw-global-error-handler',
+    readyLocator: (page) => page.getByRole('button', { name: 'Invoke error' })
+})

--- a/src/app/logging/in-memory-logging-demo/in-memory-logging-demo.e2e-spec.ts
+++ b/src/app/logging/in-memory-logging-demo/in-memory-logging-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'in-memory logging demo has no WCAG 2.2 AA violations',
+    path: 'in-memory-logging',
+    includeSelector: 'ppw-in-memory-logging-demo',
+    readyLocator: (page) => page.getByRole('button', { name: 'Add debug line' })
+})

--- a/src/app/message-bar/message-bar.e2e-spec.ts
+++ b/src/app/message-bar/message-bar.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'message bar demo has no WCAG 2.2 AA violations',
+    path: 'components/message-bar',
+    includeSelector: 'ppw-message-bar-demo',
+    readyLocator: (page) => page.getByRole('heading', { name: 'Message bar with input parameter message' })
+})

--- a/src/app/table/table-demo.e2e-spec.ts
+++ b/src/app/table/table-demo.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { verifyE2eA11y } from '@ppwcode/ng-e2e-testing'
+
+verifyE2eA11y({
+    name: 'table demo has no WCAG 2.2 AA violations',
+    path: 'components/table',
+    includeSelector: 'ppw-table-demo',
+    readyLocator: (page) => page.getByRole('heading', { name: 'Filter table' })
+})

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,7 +13,7 @@ $ppw-primary-palette: (
     200: #80cd9f,
     300: #4db978,
     400: #26aa5b,
-    500: #009b3e,
+    500: #007f28,
     600: #009338,
     700: #008930,
     800: #007f28,
@@ -86,12 +86,13 @@ body {
     --ppw-confirmation-dialog-header-text-color: #{mat.m2-get-contrast-color-from-palette($ppw-primary-palette, 500)};
 
     --ppw-expandable-card-header-text-color: white;
-    --ppw-expandable-card-header-background-color: #6eb343;
+    --ppw-expandable-card-header-background-color: #007f28;
     --ppw-expandable-card-header-indicator-color: white;
 
     --ppw-loader-content-padding: 16px;
 
     --ppw-message-bar-warning-text-color: black;
+    --ppw-message-bar-success-background-color: #007f28;
 
     --ppw-sidenav-background-color: #18428c;
     --ppw-sidenav-navigation-item-icon-color: #6eb343;
@@ -107,7 +108,7 @@ body {
 
     --ppw-dashboard-items-table-width: 750px;
     --ppw-dashboard-items-table-primary-color: #18428c;
-    --ppw-dashboard-items-table-background-color: #6eb343;
+    --ppw-dashboard-items-table-background-color: #d9ead3;
     --ppw-dashboard-wrapper-container-vertical-margin: 32px;
     --ppw-dashboard-items-card-margin: 8px;
 

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./",
+        "types": ["node"]
+    },
+    "files": [],
+    "include": ["src/app/**/*.e2e-spec.ts", "playwright.config.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
             "@ppwcode/ng-common": ["./projects/ppwcode/ng-common/src/public-api"],
             "@ppwcode/ng-common-components": ["./projects/ppwcode/ng-common-components/src/public-api"],
             "@ppwcode/ng-dialogs": ["./projects/ppwcode/ng-dialogs/src/public-api"],
+            "@ppwcode/ng-e2e-testing": ["./projects/ppwcode/ng-e2e-testing/src/public-api"],
             "@ppwcode/ng-forms": ["./projects/ppwcode/ng-forms/src/public-api"],
             "@ppwcode/ng-router": ["./projects/ppwcode/ng-router/src/public-api"],
             "@ppwcode/ng-state-management": ["./projects/ppwcode/ng-state-management/src/public-api"],


### PR DESCRIPTION
Add new `@ppwcode/ng-e2e-testing` library to provide helper functions for AXE a11y testing in Playwright.