### PR TITLE
fix(wireframe): Make sure sidenav items are closeable when a child is active

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.spec.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.spec.ts
@@ -139,6 +139,19 @@ describe('Left sidenav component', () => {
         expect(getNavigationItemButton('Navigation item 2')).toBeTruthy()
     })
 
+    it('should collapse parents with an active child when explicitly closed', () => {
+        vi.spyOn(router, 'isActive').mockImplementation((url) => url === '/item-2')
+
+        fixture.componentRef.setInput('navigationItems', [...navigationItems])
+        fixture.detectChanges()
+
+        expect(component.navigationItemIsOpened(childrenNavigationItem)).toBe(true)
+
+        component.onClickNavigationItem(childrenNavigationItem)
+
+        expect(component.navigationItemIsOpened(childrenNavigationItem)).toBe(false)
+    })
+
     it('should not call the active route helper when unrelated template state changes', () => {
         const navigationItemIsActiveSpy = vi.spyOn(component, 'navigationItemIsActive')
 

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.ts
@@ -54,6 +54,7 @@ export class LeftSidenavComponent implements OnChanges {
         )
     )
     private _openedNavigationItems: Array<string> = []
+    private _closedNavigationItems: Array<string> = []
 
     protected navigationItemsWithActiveState = computed<Array<NavigationItemWithActiveState>>(() =>
         this.addActiveStateToNavigationItems(this.navigationItems() ?? [], this._currentUrl())
@@ -66,9 +67,12 @@ export class LeftSidenavComponent implements OnChanges {
     }
 
     public navigationItemIsOpened(navigationItem: NavigationItem): boolean {
+        const navigationItemKey = this.getNavigationItemKey(navigationItem)
+
         return (
-            this._openedNavigationItems.includes(this.getNavigationItemKey(navigationItem)) ||
-            this.navigationItemHasActiveChild(navigationItem)
+            !this._closedNavigationItems.includes(navigationItemKey) &&
+            (this._openedNavigationItems.includes(navigationItemKey) ||
+                this.navigationItemHasActiveChild(navigationItem))
         )
     }
 
@@ -119,13 +123,17 @@ export class LeftSidenavComponent implements OnChanges {
     }
 
     private closeNavigationItem(navigationItem: NavigationItem): void {
-        this._openedNavigationItems = this._openedNavigationItems.filter(
-            (ni) => ni !== this.getNavigationItemKey(navigationItem)
-        )
+        const navigationItemKey = this.getNavigationItemKey(navigationItem)
+
+        this._openedNavigationItems = this._openedNavigationItems.filter((ni) => ni !== navigationItemKey)
+        this._closedNavigationItems.push(navigationItemKey)
     }
 
     private openNavigationItem(navigationItem: NavigationItem): void {
-        this._openedNavigationItems.push(this.getNavigationItemKey(navigationItem))
+        const navigationItemKey = this.getNavigationItemKey(navigationItem)
+
+        this._closedNavigationItems = this._closedNavigationItems.filter((ni) => ni !== navigationItemKey)
+        this._openedNavigationItems.push(navigationItemKey)
     }
 
     private validateNavigationItems(navigationItems: Array<NavigationItem> | null): void {


### PR DESCRIPTION
Keeps track of closed navigation items to fix an issue where navigation items were not closeable when a child item was active.