### PR TITLE
fix(wireframe): Don't rely on possibly unavailable layouting classes in left-sidenav

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
@@ -7,7 +7,7 @@
 <div class="ppw-sidenav-content-wrapper">
     <div class="ppw-sidenav-top-content-wrapper">
         @if (logoUrl()) {
-            <div class="flex-column logo-wrapper" [ngClass]="{ 'align-items-center': centerLogo() }">
+            <div class="logo-wrapper" [class.logo-wrapper--centered]="centerLogo()">
                 <img [ngSrc]="logoUrl()!" alt="Logo" [height]="logoHeight()" [width]="logoWidth()" priority="eager" />
             </div>
         }
@@ -53,7 +53,7 @@
         }
     </button>
     @if (navigationItemIsOpened(navigationItem) && navigationItem.children && !navigationItem.isExternalLink) {
-        <div class="ppw-sidenav-navigation-item-children-wrapper flex-column">
+        <div class="ppw-sidenav-navigation-item-children-wrapper">
             @for (child of navigationItem.children; track trackNavigationItem(child)) {
                 <ng-container
                     *ngTemplateOutlet="

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
@@ -18,6 +18,15 @@
             display: flex;
             flex-direction: column;
             flex-grow: 1;
+
+            .logo-wrapper {
+                display: flex;
+                flex-direction: column;
+
+                &--centered {
+                    align-items: center;
+                }
+            }
         }
 
         .ppw-sidenav-bottom-content-wrapper {
@@ -28,11 +37,6 @@
             padding: 16px;
         }
     }
-}
-
-.flex-column {
-    display: flex;
-    flex-direction: column;
 }
 
 .ppw-sidenav-close-button {
@@ -125,6 +129,8 @@
 }
 
 .ppw-sidenav-navigation-item-children-wrapper {
+    display: flex;
+    flex-direction: column;
     margin: var(--ppw-sidenav-navigation-item-children-wrapper-margin, 0);
     padding: var(--ppw-sidenav-navigation-item-children-wrapper-padding, 0);
     border: var(--ppw-sidenav-navigation-item-children-wrapper-border, none);


### PR DESCRIPTION
These classes are within a previous version of the new project setup guidelines but are not part of the SDK. This causes unexpected issues in new projects not defining flex-column or align-items-center.

Closes #124 