### PR TITLE
fix(wireframe): Remove obsolete align-items-center from ppw-toolbar

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/toolbar/toolbar.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/toolbar/toolbar.component.html
@@ -1,5 +1,5 @@
 <div class="ppw-toolbar" [style.height.px]="toolbarHeightPx()">
-    <div class="ppw-toolbar-left-section align-items-center">
+    <div class="ppw-toolbar-left-section">
         @if (showMenuToggle()) {
             <button class="ppw-toolbar-button" (click)="toggleSidebar.emit()">
                 @if (!isSidenavOpen()) {


### PR DESCRIPTION
This class was no longer necessary because the styles are already applied on the ppw-toolbar-left-section class.