### PR TITLE
chore: Add skill to bump the version

### DIFF
--- a/.agents/skills/ppw-angular-sdk-releaser/SKILL.md
+++ b/.agents/skills/ppw-angular-sdk-releaser/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ppw-angular-sdk-releaser
+description: Use when preparing a PPWCode Angular SDK release version bump by updating library package versions, internal PPWCode dependency ranges, the ng-add PPWCode version constant, the demo version display, formatting, linting, and committing the bump. Don't use for npm publishing, GitHub releases, tagging, changelog generation, or generic SDK API guidance.
+---
+
+# PPWCode Angular SDK Releaser
+
+## Workflow
+
+1. Extract the target version from the user's request.
+2. If no target version was provided, ask the user for the new version number before continuing.
+3. Run `node .agents/skills/ppw-angular-sdk-releaser/scripts/bump-version.js <version>`.
+4. If the script exits with a non-zero status because the target version is lower than the current library version, stop the workflow and notify the user that the version number is wrong.
+5. Run `npm run format:lint`.
+6. Run `npm run format:prettier`.
+7. Inspect `git status --short` and confirm that only the intended release bump files changed.
+8. Commit the release bump with `git commit -am "Bump version to <version>"`.
+
+## Release Bump Script
+
+Use `scripts/bump-version.js` for deterministic version updates. The script updates:
+
+-   `version` fields in `projects/ppwcode/*/package.json`.
+-   Internal `@ppwcode/*` dependency ranges in those package files to `^<version>`.
+-   `versions.ppwcode` in `projects/ppwcode/ng-sdk/schematics/ng-add/dependencies/versions.ts`.
+-   The displayed `v<version>` in `src/app/app.component.html` inside the `.version-info` block.
+
+## Error Handling
+
+-   If the user did not provide a version, ask for a SemVer-style version such as `21.5.1`.
+-   If `scripts/bump-version.js` reports an invalid or lower version, stop without formatting or committing.
+-   If formatting or linting fails, stop and report the failing command.
+-   If unrelated changes are present before committing, do not include them; ask the user how to proceed if the release bump cannot be committed cleanly.
+-   If the commit fails, report the Git error and leave the changed files in place.

--- a/.agents/skills/ppw-angular-sdk-releaser/scripts/bump-version.js
+++ b/.agents/skills/ppw-angular-sdk-releaser/scripts/bump-version.js
@@ -1,0 +1,219 @@
+const fs = require('fs')
+const path = require('path')
+
+const repoRoot = process.cwd()
+const packagesRoot = path.join(repoRoot, 'projects', 'ppwcode')
+const versionsFile = path.join(
+    repoRoot,
+    'projects',
+    'ppwcode',
+    'ng-sdk',
+    'schematics',
+    'ng-add',
+    'dependencies',
+    'versions.ts'
+)
+const appComponentHtml = path.join(repoRoot, 'src', 'app', 'app.component.html')
+
+const semverPattern =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+
+const fail = (message) => {
+    console.error(message)
+    process.exit(1)
+}
+
+const parseVersion = (version) => {
+    const match = version.match(semverPattern)
+
+    if (!match) {
+        fail(`Invalid version "${version}". Expected a SemVer-style version such as 21.5.1.`)
+    }
+
+    return {
+        raw: version,
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+        prerelease: match[4]?.split('.') ?? []
+    }
+}
+
+const comparePrerelease = (left, right) => {
+    if (!left.length && !right.length) {
+        return 0
+    }
+
+    if (!left.length) {
+        return 1
+    }
+
+    if (!right.length) {
+        return -1
+    }
+
+    const length = Math.max(left.length, right.length)
+
+    for (let index = 0; index < length; index++) {
+        const leftPart = left[index]
+        const rightPart = right[index]
+
+        if (leftPart === undefined) {
+            return -1
+        }
+
+        if (rightPart === undefined) {
+            return 1
+        }
+
+        const leftNumeric = /^\d+$/.test(leftPart)
+        const rightNumeric = /^\d+$/.test(rightPart)
+
+        if (leftNumeric && rightNumeric) {
+            const difference = Number(leftPart) - Number(rightPart)
+
+            if (difference !== 0) {
+                return difference
+            }
+
+            continue
+        }
+
+        if (leftNumeric) {
+            return -1
+        }
+
+        if (rightNumeric) {
+            return 1
+        }
+
+        if (leftPart !== rightPart) {
+            return leftPart.localeCompare(rightPart)
+        }
+    }
+
+    return 0
+}
+
+const compareVersions = (left, right) => {
+    for (const part of ['major', 'minor', 'patch']) {
+        const difference = left[part] - right[part]
+
+        if (difference !== 0) {
+            return difference
+        }
+    }
+
+    return comparePrerelease(left.prerelease, right.prerelease)
+}
+
+const readPackageJsonFiles = () => {
+    if (!fs.existsSync(packagesRoot)) {
+        fail(`Could not find packages directory: ${packagesRoot}`)
+    }
+
+    return fs
+        .readdirSync(packagesRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(packagesRoot, entry.name, 'package.json'))
+        .filter((packageJsonPath) => fs.existsSync(packageJsonPath))
+        .sort()
+}
+
+const readPackageJson = (packageJsonPath) => {
+    try {
+        return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    } catch (error) {
+        fail(`Could not parse ${packageJsonPath}: ${error.message}`)
+    }
+}
+
+const updatePpwcodeDependencyRanges = (packageJson, newVersion) => {
+    for (const dependencySection of ['dependencies', 'peerDependencies', 'devDependencies']) {
+        const dependencies = packageJson[dependencySection]
+
+        if (!dependencies) {
+            continue
+        }
+
+        for (const dependencyName of Object.keys(dependencies)) {
+            if (dependencyName.startsWith('@ppwcode/')) {
+                dependencies[dependencyName] = `^${newVersion}`
+            }
+        }
+    }
+}
+
+const updateVersionsFile = (newVersion) => {
+    const content = fs.readFileSync(versionsFile, 'utf8')
+    const ppwcodeVersionPattern = /(ppwcode:\s*')[^']+(')/
+
+    if (!ppwcodeVersionPattern.test(content)) {
+        fail(`Could not update versions.ppwcode in ${versionsFile}`)
+    }
+
+    const updatedContent = content.replace(ppwcodeVersionPattern, `$1${newVersion}$2`)
+
+    fs.writeFileSync(versionsFile, updatedContent)
+}
+
+const updateAppComponentHtml = (newVersion) => {
+    const content = fs.readFileSync(appComponentHtml, 'utf8')
+    const versionInfoPattern = /(<div\s+class="version-info"\s*>\s*<div>)v[^<]+(<\/div>\s*<\/div>)/
+
+    if (!versionInfoPattern.test(content)) {
+        fail(`Could not update .version-info in ${appComponentHtml}`)
+    }
+
+    const updatedContent = content.replace(versionInfoPattern, `$1v${newVersion}$2`)
+
+    fs.writeFileSync(appComponentHtml, updatedContent)
+}
+
+const newVersion = process.argv[2]
+
+if (!newVersion) {
+    fail('Missing version. Usage: node .agents/skills/ppw-angular-sdk-releaser/scripts/bump-version.js <version>')
+}
+
+const parsedNewVersion = parseVersion(newVersion)
+const packageJsonFiles = readPackageJsonFiles()
+
+if (!packageJsonFiles.length) {
+    fail(`No library package.json files found under ${packagesRoot}`)
+}
+
+const packageJsonEntries = packageJsonFiles.map((packageJsonPath) => ({
+    path: packageJsonPath,
+    packageJson: readPackageJson(packageJsonPath)
+}))
+const currentVersions = [...new Set(packageJsonEntries.map((entry) => entry.packageJson.version))]
+
+if (currentVersions.some((version) => !version)) {
+    fail('One or more library package.json files are missing a version field.')
+}
+
+if (currentVersions.length !== 1) {
+    fail(`Library package versions are inconsistent: ${currentVersions.join(', ')}`)
+}
+
+const currentVersion = currentVersions[0]
+const parsedCurrentVersion = parseVersion(currentVersion)
+
+if (compareVersions(parsedNewVersion, parsedCurrentVersion) < 0) {
+    fail(`New version ${newVersion} is lower than current version ${currentVersion}. Release bump stopped.`)
+}
+
+for (const entry of packageJsonEntries) {
+    entry.packageJson.version = newVersion
+    updatePpwcodeDependencyRanges(entry.packageJson, newVersion)
+    fs.writeFileSync(entry.path, JSON.stringify(entry.packageJson, null, 4) + '\n')
+}
+
+updateVersionsFile(newVersion)
+updateAppComponentHtml(newVersion)
+
+console.log(`Updated ${packageJsonEntries.length} library package.json files to ${newVersion}.`)
+console.log(`Updated internal @ppwcode/* dependency ranges to ^${newVersion}.`)
+console.log(`Updated ${path.relative(repoRoot, versionsFile)}.`)
+console.log(`Updated ${path.relative(repoRoot, appComponentHtml)}.`)


### PR DESCRIPTION
Introduces a skill that executes a script for bumping the version and do the necessary validations.

<img width="976" height="370" alt="image" src="https://github.com/user-attachments/assets/99556676-648a-48bd-af09-9e12e293085e" />

Also works implicitly:
<img width="954" height="539" alt="image" src="https://github.com/user-attachments/assets/686e84e9-e2d0-47ac-93e0-faeaca9affae" />

