### PR TITLE
fix(wireframe): replace flex-column in left-sidenav navigation wrapper with actual styles

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
@@ -14,7 +14,7 @@
         <div class="ppw-sidenav-top-content">
             <ng-content select="[ppw-sidebar-top]"></ng-content>
         </div>
-        <div class="ppw-sidenav-navigation-wrapper flex-column">
+        <div class="ppw-sidenav-navigation-wrapper">
             @for (navigationItem of navigationItemsWithActiveState(); track trackNavigationItem(navigationItem)) {
                 <ng-container *ngTemplateOutlet="navigationItemTemplate; context: { navigationItem }"></ng-container>
             }

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
@@ -27,6 +27,11 @@
                     align-items: center;
                 }
             }
+
+            .ppw-sidenav-navigation-wrapper {
+                display: flex;
+                flex-direction: column;
+            }
         }
 
         .ppw-sidenav-bottom-content-wrapper {


### PR DESCRIPTION
This one slipped through last PR.