### PR TITLE
feat(wireframe): allow sidebar navigation to conditionally be the only scrollable element in the left sidenav

### DIFF
--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.html
@@ -14,7 +14,10 @@
         <div class="ppw-sidenav-top-content">
             <ng-content select="[ppw-sidebar-top]"></ng-content>
         </div>
-        <div class="ppw-sidenav-navigation-wrapper">
+        <div
+            class="ppw-sidenav-navigation-wrapper"
+            [class.ppw-sidenav-navigation-wrapper--scroll-only]="scrollNavigationWrapperOnly()"
+        >
             @for (navigationItem of navigationItemsWithActiveState(); track trackNavigationItem(navigationItem)) {
                 <ng-container *ngTemplateOutlet="navigationItemTemplate; context: { navigationItem }"></ng-container>
             }

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.scss
@@ -5,6 +5,31 @@
     flex-direction: column;
     height: 100%;
 
+    // This ensures that the navigation wrapper is the only element scrolling.
+    // The class is applied when the sidebar configuration option is set to true.
+    &.ppw-sidenav-scroll-navigation-wrapper-only {
+        min-height: 0;
+
+        .ppw-sidenav-content-wrapper,
+        .ppw-sidenav-top-content-wrapper {
+            min-height: 0;
+        }
+
+        .ppw-sidenav-top-content-wrapper {
+            flex-grow: 0;
+            flex-shrink: 1;
+        }
+
+        .ppw-sidenav-navigation-wrapper {
+            min-height: 0;
+            overflow-y: auto;
+        }
+
+        .ppw-sidenav-bottom-content-wrapper {
+            flex-shrink: 0;
+        }
+    }
+
     .ppw-sidenav-content-wrapper {
         display: flex;
         flex-direction: column;

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.spec.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.spec.ts
@@ -68,6 +68,21 @@ describe('Left sidenav component', () => {
         return navigationItemButton
     }
 
+    function getNavigationWrapper(): HTMLElement {
+        return fixture.nativeElement.querySelector('.ppw-sidenav-navigation-wrapper')
+    }
+
+    it('should not scroll only the navigation wrapper by default', () => {
+        expect(getNavigationWrapper().classList).not.toContain('ppw-sidenav-navigation-wrapper--scroll-only')
+    })
+
+    it('should scroll only the navigation wrapper when enabled', () => {
+        fixture.componentRef.setInput('scrollNavigationWrapperOnly', true)
+        fixture.detectChanges()
+
+        expect(getNavigationWrapper().classList).toContain('ppw-sidenav-navigation-wrapper--scroll-only')
+    })
+
     it('should do nothing when clicking disabled navigation items', () => {
         expect(component.navigationItemIsOpened(disabledNavigationItem)).toBe(false)
 

--- a/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/left-sidenav/left-sidenav.component.ts
@@ -30,6 +30,9 @@ interface NavigationItemWithActiveState extends NavigationItem {
     imports: [CommonModule, MatIconModule, MatListModule, TranslatePipe, NgOptimizedImage],
     templateUrl: './left-sidenav.component.html',
     styleUrls: ['./left-sidenav.component.scss'],
+    host: {
+        '[class.ppw-sidenav-scroll-navigation-wrapper-only]': 'scrollNavigationWrapperOnly()'
+    },
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LeftSidenavComponent implements OnChanges {
@@ -40,6 +43,7 @@ export class LeftSidenavComponent implements OnChanges {
     public logoHeight: InputSignal<number> = input(100)
     public logoWidth: InputSignal<number> = input(100)
     public centerLogo: InputSignal<boolean> = input(true)
+    public scrollNavigationWrapperOnly: InputSignal<boolean> = input(false)
 
     // Outputs
     public closeSidebar: OutputEmitterRef<void> = output()

--- a/projects/ppwcode/ng-wireframe/src/lib/model/sidebar-options.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/model/sidebar-options.ts
@@ -5,4 +5,5 @@ export interface SidebarOptions {
     centerLogo?: boolean
     showPageTitle?: boolean
     closedByDefaultOnLargerDevice?: boolean
+    scrollNavigationWrapperOnly?: boolean
 }

--- a/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.html
+++ b/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.html
@@ -18,6 +18,7 @@
                 [logoHeight]="sidebarOptions()?.logoHeight ?? 100"
                 [logoWidth]="sidebarOptions()?.logoWidth ?? 100"
                 [showMenuCloseButton]="isXSmallDevice() || !!sidebarOptions()?.closedByDefaultOnLargerDevice"
+                [scrollNavigationWrapperOnly]="!!sidebarOptions()?.scrollNavigationWrapperOnly"
             >
                 <div ppw-sidebar-top class="ppw-sidebar-top-content">
                     <ng-content select="[ppw-sidebar-top-content]"></ng-content>

--- a/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.spec.ts
+++ b/projects/ppwcode/ng-wireframe/src/lib/wireframe/wireframe.component.spec.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
 import { provideRouter, Route, Router } from '@angular/router'
 import { provideTranslateService } from '@ngx-translate/core'
 import { provideBreadcrumbOptions } from '@ppwcode/ng-router'
+import { LeftSidenavComponent } from '../left-sidenav/left-sidenav.component'
 import { provideWireframeOptions, WireframeOptions } from '../model/wireframe-options'
 import { WireframeComponent } from './wireframe.component'
 
@@ -129,6 +131,29 @@ describe('WireframeComponent', () => {
 
         expect(component.showToolbar()).toBe(true)
         expect(fixture.nativeElement.querySelector('ppw-toolbar')).toBeTruthy()
+    })
+
+    it('should not scroll only the navigation wrapper by default', async () => {
+        await setup()
+        await router.navigateByUrl('/visible')
+        fixture.detectChanges()
+
+        const leftSidenav = fixture.debugElement.query(By.directive(LeftSidenavComponent))
+            .componentInstance as LeftSidenavComponent
+
+        expect(leftSidenav.scrollNavigationWrapperOnly()).toBe(false)
+    })
+
+    it('should pass the navigation wrapper only scroll option to the left sidenav', async () => {
+        await setup()
+        fixture.componentRef.setInput('sidebarOptions', { scrollNavigationWrapperOnly: true })
+        await router.navigateByUrl('/visible')
+        fixture.detectChanges()
+
+        const leftSidenav = fixture.debugElement.query(By.directive(LeftSidenavComponent))
+            .componentInstance as LeftSidenavComponent
+
+        expect(leftSidenav.scrollNavigationWrapperOnly()).toBe(true)
     })
 
     it('should keep the breadcrumb visible when the toolbar is hidden by route data', async () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,7 +44,8 @@ export class AppComponent extends mixinResponsiveObservers() {
             logoUrl: './assets/ppwcode_logo.png',
             centerLogo: false,
             closedByDefaultOnLargerDevice: this.closedByDefaultOnLargerDevice(),
-            showPageTitle: this.showPageTitle()
+            showPageTitle: this.showPageTitle(),
+            scrollNavigationWrapperOnly: true
         }
     })
 


### PR DESCRIPTION
**When set to true**
<img width="406" height="859" alt="image" src="https://github.com/user-attachments/assets/acbbbe81-20c5-4c06-b5ac-fbc01102540d" />

**When set to false (default for backwards compatibility)**
<img width="369" height="856" alt="image" src="https://github.com/user-attachments/assets/c0938ca2-2d3a-457f-a76e-254ab9922d40" />
